### PR TITLE
Feature: 포켓몬 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -44,21 +44,22 @@ export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => 
 
 // 포켓몬 도감 리스트 데이터
 // Todo 더보기 버튼 클릭시 offset와 limit로 추가 데이터 불러오도록 하기
-export const getPokemonAllList = async () => {
+export const getPokemonAllList = async ({ offset = 0, limit = 20 }) => {
   // offset: 몇번째 부터 불러올지 정하는 값, limit: 몇개의 데이터를 불러올지 정하는 값
-  const pokemonAllListResponse = await fetchPokemonListData({ offset: 0, limit: 20 });
-  const pokemonPromises = pokemonAllListResponse.results.map((result: Language) => {
+  const pokemonAllListResponse = await fetchPokemonListData({ offset, limit });
+  const pokemonPromises: PokemonInfo[] = pokemonAllListResponse.results.map((result: Language) => {
     const pokemonQuery = result.name;
     return getPokemonInfo({ number: pokemonQuery, language: 'ko' });
   });
   const pokemonAllList = await Promise.all(pokemonPromises);
-  return pokemonAllList;
+  return pokemonAllList as PokemonInfo[];
 };
 
 // 포켓몬 랜덤 이미지(로딩, 퀴즈)
 let defaultNumber: number | null = null; // 두번 호출되어 서로 다른 데이터를 호출하는 현상 방지 코드
 export const getPokemonRandomImage = async () => {
   if (defaultNumber === null) {
+    // 마지막 포켓몬 번호 1025라서 1~1025 랜던 번호
     defaultNumber = Math.floor(Math.random() * 1025 + 1);
   }
 
@@ -66,5 +67,5 @@ export const getPokemonRandomImage = async () => {
   const pokemonRandomImage =
     pokemonData.sprites.versions['generation-v']['black-white'].animated.front_default ||
     pokemonData.sprites.front_default;
-  return pokemonRandomImage;
+  return pokemonRandomImage as string;
 };

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -1,98 +1,41 @@
+import { fetchPokemonData, fetchSpeciesData, fetchEvolutionData } from './fetch';
+import { GetPokemonParams, PokemonInfo } from './type';
 import axiosInstance from './instance';
 import {
-  PokemonLanguage,
-  PokemonType,
-  PokemonFlavor,
-  PokemonAbility,
-  PokemonAbilityFlavor,
-  GetPokemonParams,
-} from './type';
-import { END_POINT } from './path';
+  getPokemonName,
+  getPokemonGenus,
+  getFlavorText,
+  getPokemonTypes,
+  getImages,
+  getAbilities,
+} from './getPokemonData';
 
-// 전체 데이터
-export const fetchPokemonData = async (number?: number) => {
-  try {
-    const response = await axiosInstance.get(`${END_POINT.pokemon}${number ? number : ''}`);
-    console.log(response.data.results);
-    return response.data;
-  } catch (error) {
-    console.error(error);
-  }
-};
-
-// 포켓몬 정보(번호, 체중, 신장, 이름, 분류, 설명, 타입, 이미지, 특성)
-export const getPokemonInfo = async ({ number, language, shiny }: GetPokemonParams) => {
+export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => {
   try {
     const pokemonData = await fetchPokemonData(number);
+    const speciesData = await fetchSpeciesData(number);
+
     const { id, weight, height, abilities, types } = pokemonData;
 
-    // 이름 데이터
-    const speciesResponse = await axiosInstance.get(`${END_POINT.species}${number}`);
-    const pokemonNameList = speciesResponse.data.names;
-    const pokemonName = pokemonNameList.find((name: PokemonLanguage) => name.language.name === language);
-
-    // 분류 데이터
-    const pokemonGeneraList = speciesResponse.data.genera;
-    const pokemonGenera = pokemonGeneraList.find((name: PokemonLanguage) => name.language.name === language);
-
-    // 설명 데이터
-    const pokemonFlavorList = speciesResponse.data.flavor_text_entries;
-    const flavorText = pokemonFlavorList.find(
-      (flavor: PokemonFlavor) => flavor.language.name === language && flavor.version.name === 'sword',
-    );
-    const pokemonFlavor = flavorText ? flavorText.flavor_text.replace(/\n/g, ' ') : null;
-
-    // Todo 진화 단계
-    const evolutionResponse = await axiosInstance.get(`${END_POINT.evolution}${number}`);
-    const evolutionList = evolutionResponse.data.chain.evolves_to;
-
-    // 타입 데이터
-    const typeUrlList = types.map((type: PokemonType) => type.type.url);
-    const typeResponseList = await Promise.all(typeUrlList.map((typeUrl: string) => axiosInstance.get(typeUrl)));
-    const pokemonTypeList = typeResponseList.map(typeResponse => {
-      const typeNameList = typeResponse.data.names;
-      return typeNameList.find((typeName: PokemonLanguage) => typeName.language.name === language);
-    });
-
-    // 이미지 데이터
-    const pokemonImage = shiny
-      ? pokemonData.sprites.versions['generation-v']['black-white'].animated.front_shiny ||
-        pokemonData.sprites.front_shiny
-      : pokemonData.sprites.versions['generation-v']['black-white'].animated.front_default ||
-        pokemonData.sprites.front_default;
-
-    // 특성 데이터
-    const abilityUrlList = abilities.map((ability: PokemonAbility) => ability.ability.url);
-
-    const abilityResponseList = await Promise.all(
-      abilityUrlList.map((abilityUrl: string) => axiosInstance.get(abilityUrl)),
-    );
-
-    const pokemonAbilityList = abilityResponseList.map(abilityResponse => {
-      const { flavor_text_entries, names } = abilityResponse.data;
-      const abilityName = names.find((abilityName: PokemonLanguage) => abilityName.language.name === language);
-      const abilityFlavor = flavor_text_entries.find(
-        (abilityFlavor: PokemonAbilityFlavor) =>
-          abilityFlavor.language.name === language && abilityFlavor.version_group.name === 'sword-shield',
-      );
-      return {
-        name: abilityName ? abilityName.name.replace(/\n/g, ' ') : null,
-        flavor: abilityFlavor ? abilityFlavor.flavor_text.replace(/\n/g, ' ') : null,
-      };
-    });
+    const name = getPokemonName(speciesData, language);
+    const genus = getPokemonGenus(speciesData, language);
+    const flavor = getFlavorText(speciesData, language);
+    const typeList = await getPokemonTypes(types, axiosInstance, language);
+    const { pokemonImage, pokemonShinyImage } = getImages(pokemonData);
+    const abilityList = await getAbilities(abilities, axiosInstance, language);
 
     return {
-      id, // 번호
-      weight, // 체중
-      height, // 신장
-      name: pokemonName ? pokemonName.name : null, // 이름
-      genus: pokemonGenera ? pokemonGenera.genus : null, // 분류
-      flavor: pokemonFlavor, // 설명
-      evolution: evolutionList, // Todo 진화단계
-      typeList: pokemonTypeList, // 타입
-      image: pokemonImage, // 이미지
-      abilityList: pokemonAbilityList, // 특성
-    };
+      id,
+      weight,
+      height,
+      name,
+      genus,
+      flavor,
+      typeList,
+      image: pokemonImage,
+      shiny: pokemonShinyImage,
+      abilityList,
+    } as PokemonInfo;
   } catch (error) {
     console.error(error);
   }

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -1,5 +1,5 @@
-import { fetchPokemonData, fetchSpeciesData, fetchEvolutionData } from './fetch';
-import { GetPokemonParams, PokemonInfo } from './type';
+import { fetchPokemonData, fetchSpeciesData, fetchEvolutionData, fetchPokemonListData } from './fetch';
+import { GetPokemonParams, PokemonInfo, Language } from './type';
 import axiosInstance from './instance';
 import {
   getPokemonName,
@@ -42,8 +42,21 @@ export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => 
   }
 };
 
-let defaultNumber: number | null = null; // 두번 호출되어 서로 다른 데이터를 호출하는 현상 방지 코드
+// 포켓몬 도감 리스트 데이터
+// Todo 더보기 버튼 클릭시 offset와 limit로 추가 데이터 불러오도록 하기
+export const getPokemonAllList = async () => {
+  // offset: 몇번째 부터 불러올지 정하는 값, limit: 몇개의 데이터를 불러올지 정하는 값
+  const pokemonAllListResponse = await fetchPokemonListData({ offset: 0, limit: 20 });
+  const pokemonPromises = pokemonAllListResponse.results.map((result: Language) => {
+    const pokemonQuery = result.name;
+    return getPokemonInfo({ number: pokemonQuery, language: 'ko' });
+  });
+  const pokemonAllList = await Promise.all(pokemonPromises);
+  return pokemonAllList;
+};
+
 // 포켓몬 랜덤 이미지(로딩, 퀴즈)
+let defaultNumber: number | null = null; // 두번 호출되어 서로 다른 데이터를 호출하는 현상 방지 코드
 export const getPokemonRandomImage = async () => {
   if (defaultNumber === null) {
     defaultNumber = Math.floor(Math.random() * 1025 + 1);

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -10,6 +10,7 @@ import {
   getAbilities,
 } from './getPokemonData';
 
+// 포켓몬 한마리의 데이터
 export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => {
   try {
     const pokemonData = await fetchPokemonData(number);
@@ -39,4 +40,18 @@ export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => 
   } catch (error) {
     console.error(error);
   }
+};
+
+let defaultNumber: number | null = null; // 두번 호출되어 서로 다른 데이터를 호출하는 현상 방지 코드
+// 포켓몬 랜덤 이미지(로딩, 퀴즈)
+export const getPokemonRandomImage = async () => {
+  if (defaultNumber === null) {
+    defaultNumber = Math.floor(Math.random() * 1025 + 1);
+  }
+
+  const pokemonData = await fetchPokemonData(defaultNumber);
+  const pokemonRandomImage =
+    pokemonData.sprites.versions['generation-v']['black-white'].animated.front_default ||
+    pokemonData.sprites.front_default;
+  return pokemonRandomImage;
 };

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -1,0 +1,99 @@
+import axiosInstance from './instance';
+import {
+  PokemonLanguage,
+  PokemonType,
+  PokemonFlavor,
+  PokemonAbility,
+  PokemonAbilityFlavor,
+  GetPokemonParams,
+} from './type';
+import { END_POINT } from './path';
+
+// 전체 데이터
+export const fetchPokemonData = async (number?: number) => {
+  try {
+    const response = await axiosInstance.get(`${END_POINT.pokemon}${number ? number : ''}`);
+    console.log(response.data.results);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 포켓몬 정보(번호, 체중, 신장, 이름, 분류, 설명, 타입, 이미지, 특성)
+export const getPokemonInfo = async ({ number, language, shiny }: GetPokemonParams) => {
+  try {
+    const pokemonData = await fetchPokemonData(number);
+    const { id, weight, height, abilities, types } = pokemonData;
+
+    // 이름 데이터
+    const speciesResponse = await axiosInstance.get(`${END_POINT.species}${number}`);
+    const pokemonNameList = speciesResponse.data.names;
+    const pokemonName = pokemonNameList.find((name: PokemonLanguage) => name.language.name === language);
+
+    // 분류 데이터
+    const pokemonGeneraList = speciesResponse.data.genera;
+    const pokemonGenera = pokemonGeneraList.find((name: PokemonLanguage) => name.language.name === language);
+
+    // 설명 데이터
+    const pokemonFlavorList = speciesResponse.data.flavor_text_entries;
+    const flavorText = pokemonFlavorList.find(
+      (flavor: PokemonFlavor) => flavor.language.name === language && flavor.version.name === 'sword',
+    );
+    const pokemonFlavor = flavorText ? flavorText.flavor_text.replace(/\n/g, ' ') : null;
+
+    // Todo 진화 단계
+    const evolutionResponse = await axiosInstance.get(`${END_POINT.evolution}${number}`);
+    const evolutionList = evolutionResponse.data.chain.evolves_to;
+
+    // 타입 데이터
+    const typeUrlList = types.map((type: PokemonType) => type.type.url);
+    const typeResponseList = await Promise.all(typeUrlList.map((typeUrl: string) => axiosInstance.get(typeUrl)));
+    const pokemonTypeList = typeResponseList.map(typeResponse => {
+      const typeNameList = typeResponse.data.names;
+      return typeNameList.find((typeName: PokemonLanguage) => typeName.language.name === language);
+    });
+
+    // 이미지 데이터
+    const pokemonImage = shiny
+      ? pokemonData.sprites.versions['generation-v']['black-white'].animated.front_shiny ||
+        pokemonData.sprites.front_shiny
+      : pokemonData.sprites.versions['generation-v']['black-white'].animated.front_default ||
+        pokemonData.sprites.front_default;
+
+    // 특성 데이터
+    const abilityUrlList = abilities.map((ability: PokemonAbility) => ability.ability.url);
+
+    const abilityResponseList = await Promise.all(
+      abilityUrlList.map((abilityUrl: string) => axiosInstance.get(abilityUrl)),
+    );
+
+    const pokemonAbilityList = abilityResponseList.map(abilityResponse => {
+      const { flavor_text_entries, names } = abilityResponse.data;
+      const abilityName = names.find((abilityName: PokemonLanguage) => abilityName.language.name === language);
+      const abilityFlavor = flavor_text_entries.find(
+        (abilityFlavor: PokemonAbilityFlavor) =>
+          abilityFlavor.language.name === language && abilityFlavor.version_group.name === 'sword-shield',
+      );
+      return {
+        name: abilityName ? abilityName.name.replace(/\n/g, ' ') : null,
+        flavor: abilityFlavor ? abilityFlavor.flavor_text.replace(/\n/g, ' ') : null,
+      };
+    });
+
+    return {
+      id, // 번호
+      weight, // 체중
+      height, // 신장
+      name: pokemonName ? pokemonName.name : null, // 이름
+      genus: pokemonGenera ? pokemonGenera.genus : null, // 분류
+      flavor: pokemonFlavor, // 설명
+      evolution: evolutionList, // Todo 진화단계
+      typeList: pokemonTypeList, // 타입
+      image: pokemonImage, // 이미지
+      abilityList: pokemonAbilityList, // 특성
+    };
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -1,8 +1,17 @@
 import axiosInstance from './instance';
+import { GetPokemonListParams } from './type';
 import { END_POINT } from './path';
 
-// 전체 데이터
-export const fetchPokemonData = async (number: number) => {
+export const fetchPokemonListData = async ({ offset, limit }: GetPokemonListParams) => {
+  try {
+    const response = await axiosInstance.get(`${END_POINT.pokemon}?offset=${offset}&limit=${limit}`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const fetchPokemonData = async (number: number | string) => {
   try {
     const response = await axiosInstance.get(`${END_POINT.pokemon}${number}`);
     return response.data;
@@ -11,7 +20,7 @@ export const fetchPokemonData = async (number: number) => {
   }
 };
 
-export const fetchSpeciesData = async (number: number) => {
+export const fetchSpeciesData = async (number: number | string) => {
   try {
     const response = await axiosInstance.get(`${END_POINT.species}${number}`);
     return response.data;

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -1,0 +1,30 @@
+import axiosInstance from './instance';
+import { END_POINT } from './path';
+
+// 전체 데이터
+export const fetchPokemonData = async (number: number) => {
+  try {
+    const response = await axiosInstance.get(`${END_POINT.pokemon}${number}`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const fetchSpeciesData = async (number: number) => {
+  try {
+    const response = await axiosInstance.get(`${END_POINT.species}${number}`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const fetchEvolutionData = async (number: number) => {
+  try {
+    const response = await axiosInstance.get(`${END_POINT.evolution}${number}`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/lib/api/getPokemonData.ts
+++ b/src/lib/api/getPokemonData.ts
@@ -1,0 +1,61 @@
+import { PokemonLanguage, PokemonType, PokemonAbility, PokemonAbilityFlavor } from './type';
+
+// 이름 데이터 추출
+export const getPokemonName = (speciesData: any, language: string): string | null => {
+  const pokemonName = speciesData.names.find((name: PokemonLanguage) => name.language.name === language);
+  return pokemonName ? pokemonName.name : null;
+};
+
+// 분류 데이터 추출
+export const getPokemonGenus = (speciesData: any, language: string): string | null => {
+  const pokemonGenera = speciesData.genera.find((name: PokemonLanguage) => name.language.name === language);
+  return pokemonGenera ? pokemonGenera.genus : null;
+};
+
+// 설명 데이터 추출
+export const getFlavorText = (speciesData: any, language: string): string | null => {
+  const flavorText = speciesData.flavor_text_entries.find(
+    (flavor: any) => flavor.language.name === language && flavor.version.name === 'sword',
+  );
+  return flavorText ? flavorText.flavor_text.replace(/\n/g, ' ') : null;
+};
+
+// 타입 데이터 추출
+export const getPokemonTypes = async (types: PokemonType[], axiosInstance: any, language: string) => {
+  const typeResponseList = await Promise.all(types.map((type: PokemonType) => axiosInstance.get(type.type.url)));
+  return typeResponseList.map(typeResponse => {
+    const typeNameList = typeResponse.data.names;
+    return typeNameList.find((typeName: PokemonLanguage) => typeName.language.name === language);
+  });
+};
+
+// 이미지 데이터 추출
+export const getImages = (pokemonData: any) => {
+  const pokemonImage =
+    pokemonData.sprites.versions['generation-v']['black-white'].animated.front_default ||
+    pokemonData.sprites.front_default;
+  const pokemonShinyImage =
+    pokemonData.sprites.versions['generation-v']['black-white'].animated.front_shiny || pokemonData.sprites.front_shiny;
+
+  return { pokemonImage, pokemonShinyImage };
+};
+
+// 특성 데이터 추출
+export const getAbilities = async (abilities: PokemonAbility[], axiosInstance: any, language: string) => {
+  const abilityResponseList = await Promise.all(
+    abilities.map((ability: PokemonAbility) => axiosInstance.get(ability.ability.url)),
+  );
+
+  return abilityResponseList.map(abilityResponse => {
+    const { flavor_text_entries, names } = abilityResponse.data;
+    const abilityName = names.find((abilityName: PokemonLanguage) => abilityName.language.name === language);
+    const abilityFlavor = flavor_text_entries.find(
+      (abilityFlavor: PokemonAbilityFlavor) =>
+        abilityFlavor.language.name === language && abilityFlavor.version_group.name === 'sword-shield',
+    );
+    return {
+      name: abilityName ? abilityName.name.replace(/\n/g, ' ') : null,
+      flavor: abilityFlavor ? abilityFlavor.flavor_text.replace(/\n/g, ' ') : null,
+    };
+  });
+};

--- a/src/lib/api/instance.ts
+++ b/src/lib/api/instance.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const axiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_POKEMON_API,
+});
+
+export default axiosInstance;

--- a/src/lib/api/path.ts
+++ b/src/lib/api/path.ts
@@ -1,0 +1,5 @@
+export const END_POINT = {
+  pokemon: '/pokemon/',
+  species: '/pokemon-species/',
+  evolution: '/evolution-chain/',
+};

--- a/src/lib/api/type.ts
+++ b/src/lib/api/type.ts
@@ -1,0 +1,38 @@
+export interface Language {
+  name: string;
+  url: string;
+}
+
+export interface PokemonLanguage {
+  name: string;
+  language: Language;
+}
+
+export interface PokemonAbilityFlavor {
+  flavor_text: string;
+  language: Language;
+  version_group: Language;
+}
+
+export interface PokemonFlavor {
+  flavor_text: string;
+  language: Language;
+  version: Language;
+}
+
+export interface PokemonType {
+  slot: number;
+  type: Language;
+}
+
+export interface PokemonAbility {
+  slot: number;
+  is_hidden: boolean;
+  ability: Language;
+}
+
+export interface GetPokemonParams {
+  number: number;
+  language: string;
+  shiny: boolean;
+}

--- a/src/lib/api/type.ts
+++ b/src/lib/api/type.ts
@@ -32,8 +32,13 @@ export interface PokemonAbility {
 }
 
 export interface GetPokemonParams {
-  number: number;
+  number: number | string;
   language: string;
+}
+
+export interface GetPokemonListParams {
+  offset: number;
+  limit: number;
 }
 
 export interface Ability {

--- a/src/lib/api/type.ts
+++ b/src/lib/api/type.ts
@@ -34,5 +34,20 @@ export interface PokemonAbility {
 export interface GetPokemonParams {
   number: number;
   language: string;
-  shiny: boolean;
+}
+
+export interface Ability {
+  flavor: string;
+  name: string;
+}
+
+export interface PokemonInfo {
+  id: number;
+  weight: number;
+  height: number;
+  image: string;
+  name: string;
+  shiny: string;
+  abilityList: Ability[];
+  typeList: PokemonLanguage[];
 }


### PR DESCRIPTION
## ✏️ 작업 내용 요약
 - 포켓몬 데이터 가져오는 api 구현

## 📝 작업 내용 설명
 - 포켓몬의 고유번호, 언어, 이로치 여부를 입력해서 포켓몬의 데이터를 가져옵니다.
 - 가져오는 데이터 목록
   - 번호
   - 체중
   - 신장
   - 이름
   - 분류
   - 설명
   - 타입
   - 이미지
   - 특성
 

## 📷 스크린샷 (선택)
![스크린샷 2024-10-04 오후 3 37 04](https://github.com/user-attachments/assets/408addfa-8e91-4a9f-a93c-4a1bf97e50e6)


## 💬 리뷰 요구사항(선택)
- 처음에는 api를 이름, 번호, 이미지 등 각각 가져오도록 api를 따로 작성했는데 필요한 데이터들만 한번에 요청해서 가져오는게 좋을것 같아서 지금처럼 작성했습니다.
- 진화 단계는 아직 api 구현이 안되어서 다음 작업에 추가해서 pr 올려 보겠습니다.
- 리뷰 부탁드립니다.

## 🏷️ 연관된 이슈 번호
- #5 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
