### PR TITLE
Feature: 타입에 관련된 포켓몬 리스트 api구현

### DIFF
--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -1,5 +1,5 @@
-import { fetchPokemonData, fetchSpeciesData, fetchEvolutionData, fetchPokemonListData } from './fetch';
-import { GetPokemonParams, PokemonInfo, Language } from './type';
+import { fetchPokemonData, fetchSpeciesData, fetchEvolutionData, fetchPokemonListData, fetchTypeData } from './fetch';
+import { GetPokemonParams, PokemonInfo, Language, GetPokemonListParams, GetPokemonTypeListParams } from './type';
 import axiosInstance from './instance';
 import {
   getPokemonName,
@@ -8,15 +8,16 @@ import {
   getPokemonTypes,
   getImages,
   getAbilities,
+  getTypeList,
 } from './getPokemonData';
 
 // 포켓몬 한마리의 데이터
 export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => {
   try {
     const pokemonData = await fetchPokemonData(number);
-    const speciesData = await fetchSpeciesData(number);
-
-    const { id, weight, height, abilities, types } = pokemonData;
+    const { id, weight, height, abilities, types, species } = pokemonData;
+    const speciesNumber = species.url.match(/(\d+)(?=\/?$)/)[0];
+    const speciesData = await fetchSpeciesData(speciesNumber);
 
     const name = getPokemonName(speciesData, language);
     const genus = getPokemonGenus(speciesData, language);
@@ -44,7 +45,7 @@ export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => 
 
 // 포켓몬 도감 리스트 데이터
 // Todo 더보기 버튼 클릭시 offset와 limit로 추가 데이터 불러오도록 하기
-export const getPokemonAllList = async ({ offset = 0, limit = 20 }) => {
+export const getPokemonAllList = async ({ offset = 0, limit = 20 }: GetPokemonListParams) => {
   // offset: 몇번째 부터 불러올지 정하는 값, limit: 몇개의 데이터를 불러올지 정하는 값
   const pokemonAllListResponse = await fetchPokemonListData({ offset, limit });
   const pokemonPromises: PokemonInfo[] = pokemonAllListResponse.results.map((result: Language) => {
@@ -62,6 +63,27 @@ export const getLoadingImage = async (number: number) => {
     const { pokemonImage } = getImages(pokemonData);
 
     return pokemonImage;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 포켓몬 타입 필터 포켓몬 리스트(해당 타입 숫자를 넣으면 타입에 관련된 포켓몬 리스트 노출)
+export const getPokemonTypeList = async ({ number, limit = 20, offset = 0 }: GetPokemonTypeListParams) => {
+  try {
+    const typeData = await fetchTypeData(number);
+    const pokemonData = await getTypeList(typeData, axiosInstance);
+    const pokemonIdList = pokemonData
+      .slice(offset, offset + limit) // 기본으로 데이터 20개씩 가져오고 offset를 20씩 늘려주면 그 후로 포켓몬 리스트를 20개씩 가져올 수 있다.
+      .map((pokemonData: any) => pokemonData.data.id);
+
+    const pokemonList = await Promise.all(
+      pokemonIdList.map((pokemonId: any) => {
+        return getPokemonInfo({ number: pokemonId, language: 'ko' });
+      }),
+    );
+
+    return pokemonList;
   } catch (error) {
     console.error(error);
   }

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -42,6 +42,7 @@ export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => 
     console.error(error);
   }
 };
+
 // 포켓몬 도감 리스트 데이터
 // Todo 더보기 버튼 클릭시 offset와 limit로 추가 데이터 불러오도록 하기
 export const getPokemonAllList = async ({ offset = 0, limit = 20 }: GetPokemonListParams) => {
@@ -55,14 +56,6 @@ export const getPokemonAllList = async ({ offset = 0, limit = 20 }: GetPokemonLi
   return pokemonAllList as PokemonInfo[];
 };
 
-
-// 포켓몬 랜덤 이미지(로딩, 퀴즈)
-let defaultNumber: number | null = null; // 두번 호출되어 서로 다른 데이터를 호출하는 현상 방지 코드
-export const getPokemonRandomImage = async () => {
-  if (defaultNumber === null) {
-    // 마지막 포켓몬 번호 1025라서 1~1025 랜던 번호
-    defaultNumber = Math.floor(Math.random() * 1025 + 1);
-    
 // 포켓몬 로딩 이미지
 export const getLoadingImage = async (number: number) => {
   try {
@@ -110,12 +103,10 @@ export const getPokemonRandomImage = async (number: number, language = 'ko') => 
     pokemonData.sprites.versions['generation-v']['black-white'].animated.front_default ||
     pokemonData.sprites.front_default;
 
-
   if (!pokemonHint) {
     const pokemonDataRefetch = await fetchSpeciesData(number);
     pokemonHint = getFlavorText(pokemonDataRefetch, language);
   }
 
   return { pokemonRandomImage, pokemonName, pokemonHint };
-
 };

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -37,3 +37,12 @@ export const fetchEvolutionData = async (number: number) => {
     console.error(error);
   }
 };
+
+export const fetchTypeData = async (number: number) => {
+  try {
+    const response = await axiosInstance.get(`${END_POINT.type}${number}`);
+    return response.data.pokemon;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/lib/api/getPokemonData.ts
+++ b/src/lib/api/getPokemonData.ts
@@ -6,6 +6,14 @@ export const getPokemonName = (speciesData: any, language: string): string | nul
   return pokemonName ? pokemonName.name : null;
 };
 
+// 타입에 따른 포켓몬 리스트 추출
+export const getTypeList = async (typeData: any, axiosInstance: any) => {
+  const pokemonTypeList = await Promise.all(
+    typeData.map((type: any) => axiosInstance.get(`pokemon/${type.pokemon.name}`)),
+  );
+  return pokemonTypeList || null;
+};
+
 // 분류 데이터 추출
 export const getPokemonGenus = (speciesData: any, language: string): string | null => {
   const pokemonGenera = speciesData.genera.find((name: PokemonLanguage) => name.language.name === language);

--- a/src/lib/api/path.ts
+++ b/src/lib/api/path.ts
@@ -2,4 +2,5 @@ export const END_POINT = {
   pokemon: '/pokemon/',
   species: '/pokemon-species/',
   evolution: '/evolution-chain/',
+  type: '/type/',
 };

--- a/src/lib/api/type.ts
+++ b/src/lib/api/type.ts
@@ -41,6 +41,10 @@ export interface GetPokemonListParams {
   limit: number;
 }
 
+export interface GetPokemonTypeListParams extends GetPokemonListParams {
+  number: number;
+}
+
 export interface Ability {
   flavor: string;
   name: string;


### PR DESCRIPTION
## ✏️ 작업 내용 요약
- 타입에 관련된 포켓몬 리스트를 가져오는 api구현

## 📝 작업 내용 설명
- 타입에 해당되는 숫자를 넣으면 해당 타입에 포함되어있는 포켓몬 리스트를 불러옵니다.
- 불러오는 포켓몬의 데이터가 많기 때문에 limit와 offset를 사용해서 20개씩 불러오도록 합니다.
- 기존에는 포켓몬 id를 가지고 해당 포켓몬의 데이터를 가져오는 형식이었지만 id와 포켓몬 데이터에 관련된 url에 작성된 숫자가 다른 포켓몬도 존재하는 이유로 id로 가져올수 있는 데이터는 가져오고 다른 데이터들은 정규식을 사용하여 url에 작성된 번호로 다시 한번 데이터를 조회해서 가져오는 형식으로 수정했습니다.

예시 ) https://pokeapi.co/api/v2/pokemon/10277/
- 해당 경로 포켓몬 정보
Id : 10277
name: terapagos-stellar

- 상세 정보를 가져오기위한 데이터
![image](https://github.com/user-attachments/assets/e871ba66-10a7-4518-8ae0-67dd2815d2dc)

- 위의 예시처럼 Id 번호와 url 뒷자리 번호가 다른점을 확인할 수 있습니다.

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e7dc8e83-f9dc-4b76-84d7-ecf796f7baee)


## 💬 리뷰 요구사항(선택)
- 지금은 20개씩 가져오도록 되어있지만 한번에 모든 리스트를 가져오게도 가능하니 필요하시면 말씀해주세요.
- 리뷰 부탁드립니다.


## 🏷️ 연관된 이슈 번호
- #17 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
