### PR TITLE
Refactor: HTML 구조적 타당성을 고려하여 Portal을 활용하는 것으로 변경 및 스타일 조정

### DIFF
--- a/src/app/_components/draggableSearchMenu/DraggableMenuTrigger.tsx
+++ b/src/app/_components/draggableSearchMenu/DraggableMenuTrigger.tsx
@@ -6,10 +6,11 @@ import { useRef, useState } from 'react';
 import SearchMenuContainer from './SearchMenuContainer';
 import classNames from 'classnames';
 import Portal from '../modal/Portal';
+import { useToggle } from '@/hooks/useToggle';
 
 export default function DraggableMenuTrigger() {
   const [isDragging, setIsDragging] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
+  const { toggleValue, switchToggle, turnOffToggle } = useToggle();
   const dragControls = useDragControls();
   const constraintsRef = useRef(null);
   const menuContainer = useRef(null);
@@ -17,14 +18,14 @@ export default function DraggableMenuTrigger() {
   const handleMenuDisplayClick = () => {
     // 드래그가 아니라 클릭이 일어날 경우에만 메뉴가 열리도록 분기 처리
     if (!isDragging) {
-      setIsOpen(prevState => !prevState);
+      switchToggle();
     }
   };
 
   return (
     <Portal elementId="draggable">
       <div ref={constraintsRef} className="backdrop pointer-events-none draggable-z-index">
-        <SearchMenuContainer isOpenMenu={isOpen} onCloseMenuClick={handleMenuDisplayClick} />
+        <SearchMenuContainer isOpenMenu={toggleValue} onCloseMenuClick={turnOffToggle} />
         <motion.div
           ref={menuContainer}
           dragControls={dragControls}

--- a/src/app/_components/draggableSearchMenu/DraggableMenuTrigger.tsx
+++ b/src/app/_components/draggableSearchMenu/DraggableMenuTrigger.tsx
@@ -5,6 +5,7 @@ import MonsterBall from './MonsterBall';
 import { useRef, useState } from 'react';
 import SearchMenuContainer from './SearchMenuContainer';
 import classNames from 'classnames';
+import Portal from '../modal/Portal';
 
 export default function DraggableMenuTrigger() {
   const [isDragging, setIsDragging] = useState(false);
@@ -21,31 +22,32 @@ export default function DraggableMenuTrigger() {
   };
 
   return (
-    // 배경이 되는 요소는 클릭이 되지 않아야 도감 클릭에 영향을 미치지 않기 때문에 pointer-events-none 스타일 적용
-    <div ref={constraintsRef} className="backdrop pointer-events-none draggable-z-index">
-      <SearchMenuContainer isOpenMenu={isOpen} onCloseMenuClick={handleMenuDisplayClick} />
-      <motion.div
-        ref={menuContainer}
-        dragControls={dragControls}
-        drag
-        onDragStart={() => setIsDragging(true)}
-        onDragEnd={() => setIsDragging(false)}
-        whileDrag={{ cursor: 'grabbing' }}
-        className="absolute pointer-events-auto "
-        dragConstraints={constraintsRef} // 드래그 요소가 넘어가지 못하는 경계 설정
-        dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }} // 드래그 요소가 경계를 벗어날 때 튕겨서 돌아오는 효과
-        dragElastic={0.5} // 경계 구간에 얼마나 들어갈 수 있는 지 설정
-        style={{ touchAction: 'none' }} // 모바일에서 터치 가능하려면 넣어야 하는 설정
-      >
-        <div className="flex gap-5">
-          <article
-            onClick={handleMenuDisplayClick}
-            className={classNames('hover:cursor-pointer', isDragging && 'hover:cursor-grab')}
-          >
-            <MonsterBall />
-          </article>
-        </div>
-      </motion.div>
-    </div>
+    <Portal elementId="draggable">
+      <div ref={constraintsRef} className="backdrop pointer-events-none draggable-z-index">
+        <SearchMenuContainer isOpenMenu={isOpen} onCloseMenuClick={handleMenuDisplayClick} />
+        <motion.div
+          ref={menuContainer}
+          dragControls={dragControls}
+          drag
+          onDragStart={() => setIsDragging(true)}
+          onDragEnd={() => setIsDragging(false)}
+          whileDrag={{ cursor: 'grabbing' }}
+          className="absolute pointer-events-auto "
+          dragConstraints={constraintsRef} // 드래그 요소가 넘어가지 못하는 경계 설정
+          dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }} // 드래그 요소가 경계를 벗어날 때 튕겨서 돌아오는 효과
+          dragElastic={0.5} // 경계 구간에 얼마나 들어갈 수 있는 지 설정
+          style={{ touchAction: 'none' }} // 모바일에서 터치 가능하려면 넣어야 하는 설정
+        >
+          <div className="flex gap-5">
+            <article
+              onClick={handleMenuDisplayClick}
+              className={classNames('hover:cursor-pointer', isDragging && 'hover:cursor-grab')}
+            >
+              <MonsterBall />
+            </article>
+          </div>
+        </motion.div>
+      </div>
+    </Portal>
   );
 }

--- a/src/app/_components/draggableSearchMenu/MonsterBall.tsx
+++ b/src/app/_components/draggableSearchMenu/MonsterBall.tsx
@@ -4,7 +4,13 @@ import pokeBall from '@/images/items/poke-ball.webp';
 export default function MonsterBall() {
   return (
     <div className="h-10 w-10 flex justify-center items-center border rounded-md shadow-md bg-white">
-      <Image className="pointer-events-none" src={pokeBall} alt="몬스터볼 이미지" height={30} width={30} />
+      <Image
+        className="active:pointer-events-none hover:animate-wobbleHorBottom"
+        src={pokeBall}
+        alt="몬스터볼 이미지"
+        height={30}
+        width={30}
+      />
     </div>
   );
 }

--- a/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
+++ b/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
@@ -17,13 +17,16 @@ export default function SearchMenuContainer({ isOpenMenu, onCloseMenuClick }: Se
     <>
       {!isHidden && (
         <div className="pointer-events-auto">
-          <BackDrop closeModal={onCloseMenuClick} backdropBgColor="#000000" />
+          <BackDrop
+            className={classNames(isOpenMenu ? 'animate-backdropFadeIn' : 'animate-backdropFadeOut')}
+            closeModal={onCloseMenuClick}
+            backdropBgColor="#000000"
+          />
           <div className="absolute left-1/2 top-1/4 -translate-x-1/2 modal-z-index">
             <div
               className={classNames(
                 'flex gap-4 flex-col items-center',
                 isOpenMenu ? 'animate-fadeInBottom' : 'animate-fadeOutBottom',
-                isHidden && 'hidden',
               )}
             >
               <button onClick={onCloseMenuClick} className="absolute right-1 top-0 font-black">

--- a/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
+++ b/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
@@ -29,7 +29,11 @@ export default function SearchMenuContainer({ isOpenMenu, onCloseMenuClick }: Se
                 isOpenMenu ? 'animate-fadeInBottom' : 'animate-fadeOutBottom',
               )}
             >
-              <button onClick={onCloseMenuClick} className="absolute right-1 top-0 font-black">
+              <button
+                onClick={onCloseMenuClick}
+                // x가 픽셀 느낌을 위해 아이콘이 아니라 단순 소문자다보니 문자가 아래로 치우쳐 있어 글자의 중앙 정렬을 수동으로 정렬함
+                className="absolute right-0 top-0 font-black bg-white pb-[4px] pl-[10px] pr-[8px] rounded-full"
+              >
                 x
               </button>
               <Image src={defaultPokemonImage} alt="포켓몬 이미지" height={75} width={75} unoptimized priority />

--- a/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
+++ b/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
@@ -3,6 +3,7 @@ import SearchMenuContent from './SearchMenuContent';
 import Image from 'next/image';
 import defaultPokemonImage from '@/images/pokemon/pikachu.gif';
 import { useHidden } from '@/hooks/useHidden';
+import BackDrop from '../modal/BackDrop';
 
 interface SearchMenuContainerProps {
   isOpenMenu: boolean;
@@ -13,20 +14,27 @@ export default function SearchMenuContainer({ isOpenMenu, onCloseMenuClick }: Se
   const { isHidden } = useHidden(isOpenMenu);
 
   return (
-    <div className="absolute left-1/2 top-1/4 -translate-x-1/2 w-full flex justify-center pointer-events-auto">
-      <div
-        className={classNames(
-          'flex gap-4 flex-col items-center',
-          isOpenMenu ? 'visible animate-fadeInBottom' : 'animate-fadeOutBottom',
-          isHidden && 'hidden',
-        )}
-      >
-        <button onClick={onCloseMenuClick} className="absolute right-1 top-0">
-          x
-        </button>
-        <Image src={defaultPokemonImage} alt="포켓몬 이미지" height={75} width={75} unoptimized priority />
-        <SearchMenuContent />
-      </div>
-    </div>
+    <>
+      {!isHidden && (
+        <div className="pointer-events-auto">
+          <BackDrop closeModal={onCloseMenuClick} backdropBgColor="#000000" />
+          <div className="absolute left-1/2 top-1/4 -translate-x-1/2 modal-z-index">
+            <div
+              className={classNames(
+                'flex gap-4 flex-col items-center',
+                isOpenMenu ? 'animate-fadeInBottom' : 'animate-fadeOutBottom',
+                isHidden && 'hidden',
+              )}
+            >
+              <button onClick={onCloseMenuClick} className="absolute right-1 top-0 font-black">
+                x
+              </button>
+              <Image src={defaultPokemonImage} alt="포켓몬 이미지" height={75} width={75} unoptimized priority />
+              <SearchMenuContent />
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/app/_components/modal/BackDrop.tsx
+++ b/src/app/_components/modal/BackDrop.tsx
@@ -1,5 +1,3 @@
-import classNames from 'classnames';
-
 interface BackDropProps {
   closeModal: () => void;
   backdropBgColor?: string;
@@ -9,7 +7,8 @@ export default function BackDrop({ closeModal, backdropBgColor }: BackDropProps)
   return (
     <div
       onClick={closeModal}
-      className={classNames('backdrop opacity-30 modal-backdrop-z-index', backdropBgColor && `bg-[${backdropBgColor}]`)}
+      className="backdrop opacity-30 modal-backdrop-z-index"
+      style={{ backgroundColor: backdropBgColor }}
     />
   );
 }

--- a/src/app/_components/modal/BackDrop.tsx
+++ b/src/app/_components/modal/BackDrop.tsx
@@ -1,13 +1,16 @@
+import classNames from 'classnames';
+
 interface BackDropProps {
   closeModal: () => void;
   backdropBgColor?: string;
+  className?: string;
 }
 
-export default function BackDrop({ closeModal, backdropBgColor }: BackDropProps) {
+export default function BackDrop({ closeModal, backdropBgColor, className }: BackDropProps) {
   return (
     <div
       onClick={closeModal}
-      className="backdrop opacity-30 modal-backdrop-z-index"
+      className={classNames('backdrop opacity-30 modal-backdrop-z-index', className)}
       style={{ backgroundColor: backdropBgColor }}
     />
   );

--- a/src/app/_components/modal/ModalFrame.tsx
+++ b/src/app/_components/modal/ModalFrame.tsx
@@ -16,7 +16,7 @@ export default function ModalFrame({ isOpenModal, closeModal, children, backdrop
   return (
     <>
       {!isHidden && (
-        <Portal>
+        <Portal elementId="modal">
           <BackDrop closeModal={closeModal} backdropBgColor={backdropBgColor} />
           <div className="fixed modal-z-index viewport-center">
             <div className={classNames(isOpenModal ? 'animate-fadeInBottom' : 'animate-fadeOutBottom')}>{children}</div>

--- a/src/app/_components/modal/Portal.tsx
+++ b/src/app/_components/modal/Portal.tsx
@@ -1,11 +1,16 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-export default function Portal({ children }: { children: ReactNode }) {
+interface PortalProps {
+  children: ReactNode;
+  elementId: string;
+}
+
+export default function Portal({ children, elementId }: PortalProps) {
   const [portalElement, setPortalElement] = useState<Element | null>(null);
 
   useEffect(() => {
-    const portalElement = document.getElementById('portal');
+    const portalElement = document.getElementById(elementId);
     if (portalElement) {
       setPortalElement(portalElement);
     }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        {/* 드래그 가능한 몬스터볼 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}
         <div id="draggable" />
+        {/* 모달 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}
         <div id="modal" />
         <div>{children}</div>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <div id="portal" />
+        <div id="draggable" />
+        <div id="modal" />
         <div>{children}</div>
       </body>
     </html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,10 +29,28 @@ const config: Config = {
             opacity: '0',
           },
         },
+        'backdrop-fade-in': {
+          '0%': {
+            opacity: '0',
+          },
+          '100%': {
+            opacity: '0.3',
+          },
+        },
+        'backdrop-fade-out': {
+          '0%': {
+            opacity: '0.3',
+          },
+          '100%': {
+            opacity: '0',
+          },
+        },
       },
       animation: {
         fadeInBottom: 'fade-in-bottom 0.6s cubic-bezier(0.390, 0.575, 0.565, 1.000) both;',
         fadeOutBottom: 'fade-out-bottom 0.7s cubic-bezier(0.250, 0.460, 0.450, 0.940) both',
+        backdropFadeIn: 'backdrop-fade-in 0.5s ease-out both',
+        backdropFadeOut: 'backdrop-fade-out 0.5s ease-out both',
       },
       colors: {
         background: 'var(--background)',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,12 +45,37 @@ const config: Config = {
             opacity: '0',
           },
         },
+        'wobble-hor-bottom': {
+          '0%': {
+            transform: 'translateX(0%)',
+            'transform-origin': ' 50% 50%',
+            opacity: '0.8',
+            filter: 'brightness(0.7) saturate(100%)',
+          },
+          '100%': { transform: 'translateX(0%)', 'transform-origin': ' 50% 50%', opacity: '1' },
+          '15%': {
+            transform: 'translateX(-3px) rotate(-6deg)',
+          },
+          '30%': {
+            transform: 'translateX(1.5px) rotate(6deg)',
+          },
+          '45%': {
+            transform: 'translateX(-1.5px) rotate(-7.6deg)',
+          },
+          '60%': {
+            transform: 'translateX(0.9px) rotate(4.4deg)',
+          },
+          '75%': {
+            transform: 'translateX(-0.6px) rotate(-1.2deg)',
+          },
+        },
       },
       animation: {
         fadeInBottom: 'fade-in-bottom 0.6s cubic-bezier(0.390, 0.575, 0.565, 1.000) both;',
         fadeOutBottom: 'fade-out-bottom 0.7s cubic-bezier(0.250, 0.460, 0.450, 0.940) both',
         backdropFadeIn: 'backdrop-fade-in 0.5s ease-out both',
         backdropFadeOut: 'backdrop-fade-out 0.5s ease-out both',
+        wobbleHorBottom: 'wobble-hor-bottom 0.7s infinite ease-out both',
       },
       colors: {
         background: 'var(--background)',


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> HTML 구조적 타당성을 고려하여 Portal을 활용하는 것으로 변경 및 스타일 조정

## 📝 작업 내용 설명
- body 내부에 id가 'draggble'인 엘리먼트를 생성하고 해당 엘리먼트에 포탈을 열어, DraggableMenu 컴포넌트를 렌더링
- 모달 오픈 관련 로직에 useToggle 커스텀 훅을 활용하여 코드 재사용성을 높임
- 포켓몬 검색 메뉴 오픈 시 백드롭 추가
- 백드롭 영역을 클릭하면 검색 메뉴가 닫히도록 구현
- 백드롭 영역 생성 소멸 시, 모달과의 통일성을 위하여 fade in & out 애니메이션 효과 적용
- 닫기 버튼이 뒷 배경과 비슷한 색상일 경우, 시안성이 떨어지는 것을 고려하여 배경 적용
- 호버링 시에 몬스터볼이 흔들리는 애니메이션 효과 적용(실제로 만화에서 포켓몬 잡으면 몬스터볼이 흔들림)

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/5f5673f0-aced-4371-9ca5-9d573fc00099

## 💬 리뷰 요구사항(선택)
> 버그가 있거나 개선할 부분이 있다면 언제든 알려주시기 바랍니다!

## 🏷️ 연관된 이슈 번호
> [#16 Refactor: draggbleMenu 컴포넌트를 모달을 활용하도록 리팩토링](#16)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
