### PR TITLE
Feature: 타입 버튼, 타입 버튼 초기화 버튼 디자인 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["esanghe", "tanstack", "webp"]
+  "cSpell.words": ["actived", "esanghe", "tanstack", "webp"]
 }

--- a/src/app/_components/main/PokemonList.tsx
+++ b/src/app/_components/main/PokemonList.tsx
@@ -1,27 +1,13 @@
 'use client';
 import Image from 'next/image';
 import monsterBall from '@/images/items/poke-ball.webp';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { getPokemonAllList } from '@/lib/api/api';
 import matchTypeToColor from '@/utils/matchTypeToColor';
 import useInfiniteScroll from '@/hooks/useInfinityScroll';
-import { useState } from 'react';
+import usePokemonList from '@/hooks/usePokemonList';
 
 export default function PokemonList() {
-  const [hasMore, setHasMore] = useState(true);
+  const { pokemonData, fetchNextPage, hasMore } = usePokemonList();
 
-  const { data: pokemonData, fetchNextPage } = useInfiniteQuery({
-    queryKey: ['pokemon'],
-    queryFn: ({ pageParam }) => getPokemonAllList({ offset: pageParam, limit: 20 }),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages) => {
-      if (lastPage.length >= 20) {
-        return allPages.length * 20;
-      }
-      setHasMore(false);
-      return undefined;
-    },
-  });
   const { targetRef, saveScrollPosition } = useInfiniteScroll(() => {
     fetchNextPage();
     saveScrollPosition();

--- a/src/app/_components/main/SearchSection.tsx
+++ b/src/app/_components/main/SearchSection.tsx
@@ -3,9 +3,38 @@ import { PokemonTypeWithColor } from '@/lib/api/type';
 import convertHexToRGBA from '@/utils/convertHexToRGBA';
 import classNames from 'classnames';
 import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useToggle } from '@/hooks/useToggle';
+import { useHidden } from '@/hooks/useHidden';
 
+const staggerContainer = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.05,
+    },
+  },
+  exit: {
+    opacity: 0,
+    transition: {
+      staggerChildren: 0.05,
+    },
+  },
+};
+
+const item = {
+  hidden: { y: 150, opacity: 0, transition: { duration: 0.3 } },
+  show: { y: 0, opacity: 1, transition: { duration: 0.3 } },
+};
 export default function SearchSection() {
   const [activedTypes, setActivedTypes] = useState<string[]>([]);
+  const { toggleValue, switchToggle } = useToggle();
+
+  const handleResetButton = () => {
+    setActivedTypes([]);
+  };
+
   const handleTypeButton = (type: string) => {
     if (activedTypes.includes(type)) {
       setActivedTypes(prev => prev.filter(prevType => prevType !== type));
@@ -13,48 +42,63 @@ export default function SearchSection() {
     }
     setActivedTypes(prev => [...prev, type]);
   };
-  console.log(activedTypes);
+
   return (
     <div className="pt-20">
       <form className="flex w-full justify-center  gap-1 pb-10">
-        <div className="flex h-10 w-[60%] shadow-xl justify-between px-3 py-1 items-center rounded-xl bg-gray-50">
+        <div className="flex h-12 w-[60%] shadow-xl justify-between px-5 py-3 items-center rounded-xl bg-gray-50">
           <input placeholder="찾으실 포켓몬 이름을 입력하세요." className=" w-full px-3 py-1 outline-none" />
-          <button className="w-16 h-full  rounded-xl bg-gray-200">검색</button>
+          <button className="w-16 h-full  rounded-md bg-gray-200 shadow-xl">검색</button>
         </div>
       </form>
-      <div className="grid gap-3 grid-cols-6">
-        {Object.entries(PokemonTypeWithColor).map(([type, color]) => (
-          <div className="relative h-[40px] w-full">
-            <button
-              onClick={() => {
-                handleTypeButton(type);
-              }}
-              className={classNames(
-                'rounded-xl w-full flex opacity-50 hover:opacity-100 transition-all absolute justify-center py-1.5 text-white',
-              )}
-              style={
-                activedTypes.includes(type)
-                  ? {
-                      backgroundColor: color,
-                      boxShadow: `none`,
-                      top: '5px',
-                      left: '2px',
-                      transition: 'top 1s ease, left 1s ease',
-                      opacity: '1',
-                    }
-                  : {
-                      backgroundColor: color,
-                      boxShadow: `2px 5px 0 ${convertHexToRGBA(color, 0.6)}`,
-                      transition: 'top 1s ease, left 1s ease',
-                    }
-              }
-              key={type}
-            >
-              {type}
-            </button>
-          </div>
-        ))}
+      <div className="flex gap-3">
+        <button
+          className={classNames(
+            toggleValue ? 'bg-gray-200 shadow-none top-1' : 'bg-white',
+            ' px-5 py-3 flex hover:bg-gray-200 active:shadow-none active:top-1 justify-center relative rounded-xl items-center shadow-xl',
+          )}
+          onClick={switchToggle}
+        >
+          {toggleValue ? '타입 접기' : '타입 열기'}
+        </button>
+        <button
+          onClick={handleResetButton}
+          className="bg-white active:shadow-none active:top-1 relative hover:bg-gray-200 px-5 py-3 flex justify-center rounded-xl items-center shadow-xl"
+        >
+          초기화
+        </button>
       </div>
+      {toggleValue && (
+        <motion.div
+          variants={staggerContainer}
+          initial="hidden"
+          animate="show"
+          className="grid gap-3 pt-5 grid-cols-6 "
+        >
+          {Object.entries(PokemonTypeWithColor).map(([type, color]) => (
+            <motion.div variants={item} key={type} className="relative h-[40px] w-full">
+              <motion.button
+                initial={{ top: '0', boxShadow: `0px 7px 2px ${convertHexToRGBA(color, 0.6)}`, opacity: '0.5' }}
+                animate={
+                  activedTypes.includes(type)
+                    ? { top: '7px', boxShadow: `0px 0px 2px ${convertHexToRGBA(color, 0.6)}`, opacity: '1' }
+                    : { top: '0', boxShadow: `0px 7px 2px ${convertHexToRGBA(color, 0.6)}`, opacity: '0.5' }
+                }
+                whileHover={{ opacity: '1' }}
+                transition={{ duration: 0.2 }}
+                onClick={() => {
+                  handleTypeButton(type);
+                }}
+                className={classNames('rounded-md w-full flex absolute justify-center py-1.5 text-white')}
+                style={{ backgroundColor: color }}
+                key={type}
+              >
+                {type}
+              </motion.button>
+            </motion.div>
+          ))}
+        </motion.div>
+      )}
     </div>
   );
 }

--- a/src/app/_components/main/SearchSection.tsx
+++ b/src/app/_components/main/SearchSection.tsx
@@ -1,21 +1,58 @@
+'use client';
 import { PokemonTypeWithColor } from '@/lib/api/type';
-import { color } from 'framer-motion';
+import convertHexToRGBA from '@/utils/convertHexToRGBA';
+import classNames from 'classnames';
+import { useState } from 'react';
+
 export default function SearchSection() {
+  const [activedTypes, setActivedTypes] = useState<string[]>([]);
+  const handleTypeButton = (type: string) => {
+    if (activedTypes.includes(type)) {
+      setActivedTypes(prev => prev.filter(prevType => prevType !== type));
+      return;
+    }
+    setActivedTypes(prev => [...prev, type]);
+  };
+  console.log(activedTypes);
   return (
     <div className="pt-20">
-      <form className="flex w-full">
-        <input className="" />
-        <button>검색</button>
+      <form className="flex w-full justify-center  gap-1 pb-10">
+        <div className="flex h-10 w-[60%] shadow-xl justify-between px-3 py-1 items-center rounded-xl bg-gray-50">
+          <input placeholder="찾으실 포켓몬 이름을 입력하세요." className=" w-full px-3 py-1 outline-none" />
+          <button className="w-16 h-full  rounded-xl bg-gray-200">검색</button>
+        </div>
       </form>
       <div className="grid gap-3 grid-cols-6">
         {Object.entries(PokemonTypeWithColor).map(([type, color]) => (
-          <button
-            className="rounded-xl opacity-80 flex shadow-2xl justify-center py-1.5 text-white"
-            style={{ backgroundColor: `${color}` }}
-            key={type}
-          >
-            {type}
-          </button>
+          <div className="relative h-[40px] w-full">
+            <button
+              onClick={() => {
+                handleTypeButton(type);
+              }}
+              className={classNames(
+                'rounded-xl w-full flex opacity-50 hover:opacity-100 transition-all absolute justify-center py-1.5 text-white',
+              )}
+              style={
+                activedTypes.includes(type)
+                  ? {
+                      backgroundColor: color,
+                      boxShadow: `none`,
+                      top: '5px',
+                      left: '2px',
+                      transition: 'top 1s ease, left 1s ease',
+                      opacity: '1',
+                    }
+                  : {
+                      backgroundColor: color,
+                      boxShadow: `2px 5px 0 ${convertHexToRGBA(color, 0.6)}`,
+                      transition: 'top 1s ease, left 1s ease',
+                    }
+              }
+              key={type}
+            >
+              {type}
+            </button>
+          </div>
         ))}
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,8 +15,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="bg-[#A8D8A8]">
-        <div id="portal" />
-        <div>{children}</div>
+        <Providers>
+          <div id="portal" />
+          <div>{children}</div>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -16,7 +16,7 @@ export default async function MainPage() {
 
   const dehydratedState = dehydrate(queryClient);
   return (
-    <div className="max-w-[1200px]  mb-0 xl:mx-auto mt-20 rounded-xl px-5 xl:px-10 h-full bg-gray-200">
+    <div className="max-w-[1200px]  mb-0 xl:mx-auto mt-20 rounded-xl px-5 xl:px-10 h-full bg-[#F2F4F6]">
       <SearchSection />
       <HydrationBoundary state={dehydratedState}>
         <PokemonList />

--- a/src/hooks/usePokemonList.ts
+++ b/src/hooks/usePokemonList.ts
@@ -1,0 +1,22 @@
+import { getPokemonAllList } from '@/lib/api/api';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+
+const usePokemonList = () => {
+  const [hasMore, setHasMore] = useState(true);
+
+  const { data: pokemonData, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['pokemon'],
+    queryFn: ({ pageParam }) => getPokemonAllList({ offset: pageParam, limit: 20 }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.length >= 20) {
+        return allPages.length * 20;
+      }
+      setHasMore(false);
+      return undefined;
+    },
+  });
+  return { pokemonData, fetchNextPage, hasMore };
+};
+export default usePokemonList;

--- a/src/hooks/usePokemonList.ts
+++ b/src/hooks/usePokemonList.ts
@@ -1,11 +1,11 @@
 import { getPokemonAllList } from '@/lib/api/api';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 
 const usePokemonList = () => {
   const [hasMore, setHasMore] = useState(true);
 
-  const { data: pokemonData, fetchNextPage } = useInfiniteQuery({
+  const { data: pokemonData, fetchNextPage } = useSuspenseInfiniteQuery({
     queryKey: ['pokemon'],
     queryFn: ({ pageParam }) => getPokemonAllList({ offset: pageParam, limit: 20 }),
     initialPageParam: 0,
@@ -17,6 +17,7 @@ const usePokemonList = () => {
       return undefined;
     },
   });
+
   return { pokemonData, fetchNextPage, hasMore };
 };
 export default usePokemonList;

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -54,26 +54,6 @@ export const getPokemonAllList = async ({ offset = 0, limit = 20 }) => {
   return pokemonAllList as PokemonInfo[];
 };
 
-
-// 포켓몬 랜덤 이미지(로딩, 퀴즈)
-let defaultNumber: number | null = null; // 두번 호출되어 서로 다른 데이터를 호출하는 현상 방지 코드
-export const getPokemonRandomImage = async () => {
-  if (defaultNumber === null) {
-    // 마지막 포켓몬 번호 1025라서 1~1025 랜던 번호
-    defaultNumber = Math.floor(Math.random() * 1025 + 1);
-    
-// 포켓몬 로딩 이미지
-export const getLoadingImage = async (number: number) => {
-  try {
-    const pokemonData = await fetchPokemonData(number);
-    const { pokemonImage } = getImages(pokemonData);
-
-    return pokemonImage;
-  } catch (error) {
-    console.error(error);
-  }
-};
-
 // 랜덤 숫자 생성
 export const getRandomNumber = (min: number, max: number) => {
   return Math.floor(Math.random() * (max - min + 1) + min);
@@ -88,12 +68,10 @@ export const getPokemonRandomImage = async (number: number, language = 'ko') => 
     pokemonData.sprites.versions['generation-v']['black-white'].animated.front_default ||
     pokemonData.sprites.front_default;
 
-
   if (!pokemonHint) {
     const pokemonDataRefetch = await fetchSpeciesData(number);
     pokemonHint = getFlavorText(pokemonDataRefetch, language);
   }
 
   return { pokemonRandomImage, pokemonName, pokemonHint };
-
 };

--- a/src/utils/convertHexToRGBA.ts
+++ b/src/utils/convertHexToRGBA.ts
@@ -1,0 +1,10 @@
+const convertHexToRGBA = (hex: string, alpha: number) => {
+  const hexWithOutHash = hex.replace('#', '');
+  const r = parseInt(hexWithOutHash.substring(0, 2), 16);
+  const g = parseInt(hexWithOutHash.substring(2, 4), 16);
+  const b = parseInt(hexWithOutHash.substring(4, 6), 16);
+  const rgba = `rgba(${r},${g},${b},${alpha})`;
+  return rgba;
+};
+
+export default convertHexToRGBA;


### PR DESCRIPTION
## ✏️ 작업 내용 요약
타입 버튼, 타입 버튼 초기화 버튼 디자인 구현

## 📝 작업 내용 설명
클릭한 type은 state에 담는 것 까지 구현하였습니다. 해당 state를 쿼리로 활용하여 클릭한 타입의 포켓몬만 보여주면 될 것 같습니다.
디자인은 영상참고 바랍니다

+ 좁은 사이즈에서 타입버튼영역이 세로로 너무 길어지는 것을 염려하여 wrap은 적용하지 않았습니다.  반응형 디자인을 추후에 다시 고려해보겠습니다.

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/b26cced7-2798-4b9b-907a-3e8f65cc65be

## 💬 리뷰 요구사항(선택)
로직적으로 특별한 부분이 없어 주석은 달지 않았습니다 설명 요청하시면 바로 답변드리겠습니다!

## 🏷️ 연관된 이슈 번호
> #4 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [ ] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
