### PR TITLE
Feature: 포켓몬 상세 모달 구현

### DIFF
--- a/src/app/_components/landing/PokemonQuiz.tsx
+++ b/src/app/_components/landing/PokemonQuiz.tsx
@@ -93,7 +93,7 @@ export default function PokemonQuiz() {
               ref={buttonRef}
               className="h-10 min-w-[56px] px-3 rounded-lg shadow-[2px_4px_4px_rgba(0,0,0,0.2)] bg-white focus-visible:outline-none"
             >
-              {quizResult ? '다시 풀기' : '제출'}
+              {quizResult ? '다시 풀기 ⏎' : '제출'}
             </button>
           </form>
         </div>

--- a/src/app/_components/pokemonModal/PokemonModal.tsx
+++ b/src/app/_components/pokemonModal/PokemonModal.tsx
@@ -1,0 +1,203 @@
+import Image from 'next/image';
+import ModalFrame from '../modal/ModalFrame';
+import classNames from 'classnames';
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getPokemonInfo } from '@/lib/api/api';
+import { PokemonInfo, PokemonTypeWithColor } from '@/lib/api/type';
+
+interface PokemonModalProps {
+  toggleValue: boolean;
+  turnOffToggle: () => void;
+}
+
+export default function PokemonModal({ toggleValue, turnOffToggle }: PokemonModalProps) {
+  const [tabActive, setTabActive] = useState<string>('info');
+  const [shiny, setShiny] = useState<boolean>(false);
+  const [number, setNumber] = useState<number>(1);
+
+  const { data, isLoading, isError } = useQuery<PokemonInfo>({
+    queryKey: ['pokemon', number],
+    queryFn: async () => {
+      const { id, weight, height, name, genus, flavor, typeList, image, shiny, abilityList } = await getPokemonInfo({
+        number,
+        language: 'ko',
+      });
+      return { id, weight, height, name, genus, flavor, typeList, image, shiny, abilityList };
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const formattedId = data ? String(data.id).padStart(3, '0') : '000';
+  const pokemonImage = shiny ? data?.shiny : data?.image;
+
+  useEffect(() => {
+    setShiny(false);
+    setTabActive('info');
+  }, [toggleValue]);
+
+  if (isLoading) {
+    return <div>로딩중...</div>;
+  }
+
+  if (isError) {
+    return <div>에러...</div>;
+  }
+  return (
+    <ModalFrame isOpenModal={toggleValue} closeModal={turnOffToggle} backdropBgColor="#000000">
+      <div className="relative w-[700px] h-[650px] bg-[#F0F0F0] rounded-2xl p-4">
+        <button
+          type="button"
+          className={classNames(
+            'absolute top-[50%] translate-y-[-50%] left-7 w-10 h-10 pr-1 text-lg bg-[#D9D9D9] rounded-full z-10',
+            number !== 1 && 'hover:scale-110 hover:bg-white',
+          )}
+          onClick={() => {
+            setNumber(prev => prev - 1);
+          }}
+          disabled={number === 1}
+        >
+          〈
+        </button>
+        <button
+          type="button"
+          className={classNames(
+            'absolute top-[50%] translate-y-[-50%] right-7 w-10 h-10 pl-1 text-lg bg-[#D9D9D9] rounded-full transition-all z-10',
+            number !== 1025 && 'hover:scale-110 hover:bg-white',
+          )}
+          onClick={() => {
+            setNumber(prev => prev + 1);
+          }}
+          disabled={number === 1025}
+        >
+          〉
+        </button>
+        <div className="flex flex-col justify-between h-full bg-[#79C9FA] rounded-2xl">
+          <div>
+            <div className="relative pt-5 mb-5">
+              <h2 className="title-line !font-Galmuri9 text-4xl text-center text-[#F9DC42]">
+                #{formattedId} {data?.name}
+              </h2>
+              <button type="button" className="absolute top-5 right-5 text-2xl" onClick={turnOffToggle}>
+                x
+              </button>
+            </div>
+            <div className="flex justify-center items-center gap-3">
+              {data?.typeList.map((type, index) => {
+                const typeColor = PokemonTypeWithColor[type.name as keyof typeof PokemonTypeWithColor];
+                console.log(typeColor);
+                return (
+                  <button
+                    type="button"
+                    key={index}
+                    className="w-28 rounded-md flex justify-center py-1.5 text-white"
+                    style={{ backgroundColor: typeColor }}
+                  >
+                    {type.name}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="relative flex justify-center">
+            <Image
+              src={
+                pokemonImage || `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/items/poke-ball.png`
+              }
+              width={150}
+              height={150}
+              alt={data?.name ? `${data.name} 이미지` : '포켓몬 이미지'}
+            />
+          </div>
+          <div>
+            <div className="flex justify-between items-center gap-3">
+              <div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setTabActive('info');
+                  }}
+                  className={classNames(
+                    'w-24 h-8 rounded-t-lg',
+                    tabActive === 'info' ? 'bg-[#ffffff]' : 'bg-[#D9D9D9]',
+                  )}
+                >
+                  정보
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setTabActive('evolution');
+                  }}
+                  className={classNames(
+                    'w-24 h-8 rounded-t-lg',
+                    tabActive === 'evolution' ? 'bg-[#ffffff]' : 'bg-[#D9D9D9]',
+                  )}
+                >
+                  진화트리
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setTabActive('ability');
+                  }}
+                  className={classNames(
+                    'w-24 h-8 rounded-t-lg',
+                    tabActive === 'ability' ? 'bg-[#ffffff]' : 'bg-[#D9D9D9]',
+                  )}
+                >
+                  특성
+                </button>
+              </div>
+              <button
+                type="button"
+                className="flex justify-center items-center gap-3 mr-3 outline-text"
+                onClick={() => {
+                  setShiny(!shiny);
+                }}
+              >
+                <span className="relative inline-block w-10 h-5 bg-[#D9D9D9] rounded-xl">
+                  <span
+                    className={classNames(
+                      'absolute top-[2px] inline-block w-4 h-4 rounded-full transition-transform duration-300 ease-in-out',
+                      shiny ? 'bg-white translate-x-[0px]' : 'bg-[#e6e6e6] translate-x-[-16px]',
+                    )}
+                  />
+                </span>
+                이로치
+              </button>
+            </div>
+            <div className="flex flex-col justify-between w-full h-[150px] bg-black bg-opacity-50 rounded-b-2xl px-3 py-2 text-white">
+              {tabActive === 'info' && (
+                <>
+                  <p className="break-keep">{data?.flavor}</p>
+                  <div>
+                    <ul className="flex items-center gap-3">
+                      <li>분류 - {data?.genus}</li>
+                      <li>신장 - {data?.height}m</li>
+                      <li>무게 - {data?.weight}kg</li>
+                    </ul>
+                  </div>
+                </>
+              )}
+              {tabActive === 'evolution' && <div className="">진화 트리</div>}
+              {tabActive === 'ability' && (
+                <div className="">
+                  <ul>
+                    {data?.abilityList.map(ability => {
+                      return (
+                        <li key={ability.name} className="break-keep">
+                          {ability.name} - {ability.flavor}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/app/_components/pokemonModal/PokemonModal.tsx
+++ b/src/app/_components/pokemonModal/PokemonModal.tsx
@@ -7,12 +7,13 @@ import { PokemonInfo, PokemonTypeWithColor } from '@/lib/api/type';
 
 interface PokemonModalProps {
   turnOffToggle: () => void;
+  pokemonNumber: number;
 }
 
-export default function PokemonModal({ turnOffToggle }: PokemonModalProps) {
+export default function PokemonModal({ turnOffToggle, pokemonNumber }: PokemonModalProps) {
   const [tabActive, setTabActive] = useState<string>('info');
   const [shiny, setShiny] = useState<boolean>(false);
-  const [number, setNumber] = useState<number>(1);
+  const [number, setNumber] = useState<number>(pokemonNumber);
 
   const { data, isLoading, isError } = useQuery<PokemonInfo>({
     queryKey: ['pokemon', number],

--- a/src/app/_components/pokemonModal/PokemonModal.tsx
+++ b/src/app/_components/pokemonModal/PokemonModal.tsx
@@ -1,17 +1,15 @@
 import Image from 'next/image';
-import ModalFrame from '../modal/ModalFrame';
 import classNames from 'classnames';
 import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getPokemonInfo } from '@/lib/api/api';
 import { PokemonInfo, PokemonTypeWithColor } from '@/lib/api/type';
 
 interface PokemonModalProps {
-  toggleValue: boolean;
   turnOffToggle: () => void;
 }
 
-export default function PokemonModal({ toggleValue, turnOffToggle }: PokemonModalProps) {
+export default function PokemonModal({ turnOffToggle }: PokemonModalProps) {
   const [tabActive, setTabActive] = useState<string>('info');
   const [shiny, setShiny] = useState<boolean>(false);
   const [number, setNumber] = useState<number>(1);
@@ -26,6 +24,7 @@ export default function PokemonModal({ toggleValue, turnOffToggle }: PokemonModa
       return { id, weight, height, name, genus, flavor, typeList, image, shiny, abilityList };
     },
     staleTime: 1000 * 60 * 5,
+    placeholderData: keepPreviousData, // 데이터 요청이 성공할 때까지 이전 데이터를 보여준다.
   });
 
   const formattedId = data ? String(data.id).padStart(3, '0') : '000';
@@ -34,7 +33,7 @@ export default function PokemonModal({ toggleValue, turnOffToggle }: PokemonModa
   useEffect(() => {
     setShiny(false);
     setTabActive('info');
-  }, [toggleValue]);
+  }, []);
 
   if (isLoading) {
     return <div>로딩중...</div>;
@@ -44,160 +43,154 @@ export default function PokemonModal({ toggleValue, turnOffToggle }: PokemonModa
     return <div>에러...</div>;
   }
   return (
-    <ModalFrame isOpenModal={toggleValue} closeModal={turnOffToggle} backdropBgColor="#000000">
-      <div className="relative w-[700px] h-[650px] bg-[#F0F0F0] rounded-2xl p-4">
-        <button
-          type="button"
-          className={classNames(
-            'absolute top-[50%] translate-y-[-50%] left-7 w-10 h-10 pr-1 text-lg bg-[#D9D9D9] rounded-full z-10',
-            number !== 1 && 'hover:scale-110 hover:bg-white',
-          )}
-          onClick={() => {
-            setNumber(prev => prev - 1);
-          }}
-          disabled={number === 1}
-        >
-          〈
-        </button>
-        <button
-          type="button"
-          className={classNames(
-            'absolute top-[50%] translate-y-[-50%] right-7 w-10 h-10 pl-1 text-lg bg-[#D9D9D9] rounded-full transition-all z-10',
-            number !== 1025 && 'hover:scale-110 hover:bg-white',
-          )}
-          onClick={() => {
-            setNumber(prev => prev + 1);
-          }}
-          disabled={number === 1025}
-        >
-          〉
-        </button>
-        <div className="flex flex-col justify-between h-full bg-[#79C9FA] rounded-2xl">
-          <div>
-            <div className="relative pt-5 mb-5">
-              <h2 className="title-line !font-Galmuri9 text-4xl text-center text-[#F9DC42]">
-                #{formattedId} {data?.name}
-              </h2>
-              <button type="button" className="absolute top-5 right-5 text-2xl" onClick={turnOffToggle}>
-                x
-              </button>
-            </div>
-            <div className="flex justify-center items-center gap-3">
-              {data?.typeList.map((type, index) => {
-                const typeColor = PokemonTypeWithColor[type.name as keyof typeof PokemonTypeWithColor];
-                console.log(typeColor);
-                return (
-                  <button
-                    type="button"
-                    key={index}
-                    className="w-28 rounded-md flex justify-center py-1.5 text-white"
-                    style={{ backgroundColor: typeColor }}
-                  >
-                    {type.name}
-                  </button>
-                );
-              })}
-            </div>
+    <div className="relative w-[700px] h-[650px] bg-[#F0F0F0] rounded-2xl p-4">
+      {/* 이전 버튼 */}
+      <button
+        type="button"
+        className={classNames(
+          'absolute top-[50%] translate-y-[-50%] left-7 w-10 h-10 pr-1 text-lg bg-[#D9D9D9] rounded-full z-10',
+          number !== 1 && 'hover:scale-110 hover:bg-white',
+        )}
+        onClick={() => {
+          setNumber(prev => prev - 1);
+        }}
+        disabled={number === 1}
+      >
+        〈
+      </button>
+      {/* 다음 버튼 */}
+      <button
+        type="button"
+        className={classNames(
+          'absolute top-[50%] translate-y-[-50%] right-7 w-10 h-10 pl-1 text-lg bg-[#D9D9D9] rounded-full transition-all z-10',
+          number !== 1025 && 'hover:scale-110 hover:bg-white',
+        )}
+        onClick={() => {
+          setNumber(prev => prev + 1);
+        }}
+        disabled={number === 1025}
+      >
+        〉
+      </button>
+      <div className="flex flex-col justify-between h-full bg-[#79C9FA] rounded-2xl">
+        <div>
+          <div className="relative pt-5 mb-5">
+            <h2 className="title-line !font-Galmuri9 text-4xl text-center text-[#F9DC42]">
+              #{formattedId} {data?.name}
+            </h2>
+            <button type="button" className="absolute top-5 right-5 text-2xl" onClick={turnOffToggle}>
+              x
+            </button>
           </div>
-          <div className="relative flex justify-center">
-            <Image
-              src={
-                pokemonImage || `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/items/poke-ball.png`
-              }
-              width={150}
-              height={150}
-              alt={data?.name ? `${data.name} 이미지` : '포켓몬 이미지'}
-            />
+          <div className="flex justify-center items-center gap-3">
+            {data?.typeList.map((type, index) => {
+              const typeColor = PokemonTypeWithColor[type.name as keyof typeof PokemonTypeWithColor];
+              return (
+                <button
+                  type="button"
+                  key={index}
+                  className="w-28 rounded-md flex justify-center py-1.5 text-white"
+                  style={{ backgroundColor: typeColor }}
+                >
+                  {type.name}
+                </button>
+              );
+            })}
           </div>
-          <div>
-            <div className="flex justify-between items-center gap-3">
-              <div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setTabActive('info');
-                  }}
-                  className={classNames(
-                    'w-24 h-8 rounded-t-lg',
-                    tabActive === 'info' ? 'bg-[#ffffff]' : 'bg-[#D9D9D9]',
-                  )}
-                >
-                  정보
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setTabActive('evolution');
-                  }}
-                  className={classNames(
-                    'w-24 h-8 rounded-t-lg',
-                    tabActive === 'evolution' ? 'bg-[#ffffff]' : 'bg-[#D9D9D9]',
-                  )}
-                >
-                  진화트리
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setTabActive('ability');
-                  }}
-                  className={classNames(
-                    'w-24 h-8 rounded-t-lg',
-                    tabActive === 'ability' ? 'bg-[#ffffff]' : 'bg-[#D9D9D9]',
-                  )}
-                >
-                  특성
-                </button>
-              </div>
+        </div>
+        <div className="relative flex justify-center">
+          <Image
+            src={pokemonImage || `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/items/poke-ball.png`}
+            width={150}
+            height={150}
+            alt={data?.name ? `${data.name} 이미지` : '포켓몬 이미지'}
+          />
+        </div>
+        <div>
+          <div className="flex justify-between items-center gap-3">
+            <div>
               <button
                 type="button"
-                className="flex justify-center items-center gap-3 mr-3 outline-text"
                 onClick={() => {
-                  setShiny(!shiny);
+                  setTabActive('info');
                 }}
+                className={classNames('w-24 h-8 rounded-t-lg', tabActive === 'info' ? 'bg-[#ffffff]' : 'bg-[#D9D9D9]')}
               >
-                <span className="relative inline-block w-10 h-5 bg-[#D9D9D9] rounded-xl">
-                  <span
-                    className={classNames(
-                      'absolute top-[2px] inline-block w-4 h-4 rounded-full transition-transform duration-300 ease-in-out',
-                      shiny ? 'bg-white translate-x-[0px]' : 'bg-[#e6e6e6] translate-x-[-16px]',
-                    )}
-                  />
-                </span>
-                이로치
+                정보
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setTabActive('evolution');
+                }}
+                className={classNames(
+                  'w-24 h-8 rounded-t-lg',
+                  tabActive === 'evolution' ? 'bg-[#ffffff]' : 'bg-[#D9D9D9]',
+                )}
+              >
+                진화트리
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setTabActive('ability');
+                }}
+                className={classNames(
+                  'w-24 h-8 rounded-t-lg',
+                  tabActive === 'ability' ? 'bg-[#ffffff]' : 'bg-[#D9D9D9]',
+                )}
+              >
+                특성
               </button>
             </div>
-            <div className="flex flex-col justify-between w-full h-[150px] bg-black bg-opacity-50 rounded-b-2xl px-3 py-2 text-white">
-              {tabActive === 'info' && (
-                <>
-                  <p className="break-keep">{data?.flavor}</p>
-                  <div>
-                    <ul className="flex items-center gap-3">
-                      <li>분류 - {data?.genus}</li>
-                      <li>신장 - {data?.height}m</li>
-                      <li>무게 - {data?.weight}kg</li>
-                    </ul>
-                  </div>
-                </>
-              )}
-              {tabActive === 'evolution' && <div className="">진화 트리</div>}
-              {tabActive === 'ability' && (
-                <div className="">
-                  <ul>
-                    {data?.abilityList.map(ability => {
-                      return (
-                        <li key={ability.name} className="break-keep">
-                          {ability.name} - {ability.flavor}
-                        </li>
-                      );
-                    })}
+            <button
+              type="button"
+              className="flex justify-center items-center gap-3 mr-3 outline-text"
+              onClick={() => {
+                setShiny(!shiny);
+              }}
+            >
+              <span className="relative inline-block w-10 h-5 bg-[#D9D9D9] rounded-xl">
+                <span
+                  className={classNames(
+                    'absolute top-[2px] inline-block w-4 h-4 rounded-full transition-transform duration-300 ease-in-out',
+                    shiny ? 'bg-white translate-x-[0px]' : 'bg-[#e6e6e6] translate-x-[-16px]',
+                  )}
+                />
+              </span>
+              이로치
+            </button>
+          </div>
+          <div className="flex flex-col justify-between w-full h-[150px] bg-black bg-opacity-50 rounded-b-2xl px-3 py-2 text-white">
+            {tabActive === 'info' && (
+              <>
+                <p className="break-keep">{data?.flavor}</p>
+                <div>
+                  <ul className="flex items-center gap-3">
+                    <li>분류 - {data?.genus}</li>
+                    <li>신장 - {data?.height}m</li>
+                    <li>무게 - {data?.weight}kg</li>
                   </ul>
                 </div>
-              )}
-            </div>
+              </>
+            )}
+            {tabActive === 'evolution' && <div className="">진화 트리</div>}
+            {tabActive === 'ability' && (
+              <div className="">
+                <ul>
+                  {data?.abilityList.map(ability => {
+                    return (
+                      <li key={ability.name} className="break-keep">
+                        {ability.name} - {ability.flavor}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
           </div>
         </div>
       </div>
-    </ModalFrame>
+    </div>
   );
 }

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -16,7 +16,7 @@ export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => 
   try {
     const pokemonData = await fetchPokemonData(number);
     const { id, weight, height, abilities, types, species } = pokemonData;
-    const speciesNumber = species.url.match(/(\d+)(?=\/?$)/)[0];
+    const speciesNumber = species.url.match(/(\d+)(?=\/?$)/)[0]; // 포켓몬 설명 데이터를 가져오는 url에서 쿼리(고유 번호)만 가져오는 정규식
     const speciesData = await fetchSpeciesData(speciesNumber);
 
     const name = getPokemonName(speciesData, language);

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -26,10 +26,14 @@ export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => 
     const { pokemonImage, pokemonShinyImage } = getImages(pokemonData);
     const abilityList = await getAbilities(abilities, axiosInstance, language);
 
+    // 체중과 신장 값을 10으로 나눈다
+    const formattedWeight = weight < 10 ? (weight / 10).toFixed(1) : weight / 10;
+    const formattedHeight = height < 10 ? (height / 10).toFixed(1) : height / 10;
+
     return {
       id,
-      weight,
-      height,
+      weight: formattedWeight,
+      height: formattedHeight,
       name,
       genus,
       flavor,
@@ -40,6 +44,18 @@ export const getPokemonInfo = async ({ number, language }: GetPokemonParams) => 
     } as PokemonInfo;
   } catch (error) {
     console.error(error);
+    return {
+      id: 0,
+      weight: 0,
+      height: 0,
+      name: '알 수 없음',
+      genus: '알 수 없음',
+      flavor: '알 수 없음',
+      typeList: [],
+      image: '',
+      shiny: '',
+      abilityList: [],
+    } as PokemonInfo;
   }
 };
 

--- a/src/lib/api/type.ts
+++ b/src/lib/api/type.ts
@@ -58,8 +58,8 @@ export interface GetPokemonParams {
 }
 
 export interface GetPokemonListParams {
-  offset: number;
-  limit: number;
+  offset: number | undefined;
+  limit: number | undefined;
 }
 
 export interface GetPokemonTypeListParams extends GetPokemonListParams {
@@ -77,6 +77,8 @@ export interface PokemonInfo {
   height: number;
   image: string;
   name: string;
+  genus: string;
+  flavor: string;
   shiny: string;
   abilityList: Ability[];
   typeList: PokemonLanguage[];

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -31,3 +31,12 @@
   /* 재목 텍스트의 그림자 추가 */
   filter: drop-shadow(-5px 4px 0px rgba(0, 0, 0, 1));
 }
+
+.outline-text {
+  text-shadow:
+    1px 1px 0 #ffffff,
+    -1px -1px 0 #ffffff,
+    1px -1px 0 #ffffff,
+    -1px 1px 0 #ffffff;
+  color: #000000; /* 텍스트 색상 */
+}


### PR DESCRIPTION
## ✏️ 작업 내용 요약
- 포켓몬 상세 모달 구현

## 📝 작업 내용 설명
- 민찬님이 만들어주신 모달 프레임을 사용해서 팝업 열기와 닫기가 구현되었습니다.
- 이로치 토글을 클릭하면 포켓몬 이미지가 이로치 이미지로 변경됩니다.
- 오른쪽 왼쪽 아이콘을 클릭하면 현재 포켓몬 기준으로 다음과 이전 포켓몬의 데이터를 불러와서 보여줍니다.
- 정보, 진화트리, 특성 탭을 클릭하면 해당 정보에 맞는 데이터를 보여줍니다.
- 포켓몬 모달 사용 예시
```javascript
import PokemonModal from './_components/pokemonModal/PokemonModal';
import { useToggle } from '../hooks/useToggle';
import { useState } from 'react';
import ModalFrame from './_components/modal/ModalFrame';

export default function Landing() {
  const { toggleValue, switchToggle, turnOffToggle } = useToggle();
  const [pokemonNumber, setPokemonNumber] = useState<number>(1);
  const buttonTest = () => {
    switchToggle();
    setPokemonNumber(1);
  };
  return (
    <div>
      <button type="button" onClick={buttonTest}> // 버튼을 클릭하면 모달이 열리고 포켓몬 Id를 PokemonModal 전달 해야 한다.
        text button
      </button>
      <ModalFrame isOpenModal={toggleValue} closeModal={turnOffToggle}>
        <PokemonModal turnOffToggle={turnOffToggle} pokemonNumber={pokemonNumber} /> // turnOffToggle={turnOffToggle} 모달 내부에 닫기 버튼에 기능 전달
      </ModalFrame>
    </div>
  );
}

```

## 📷 스크린샷 (선택)
- 테스트 영상이라 랜딩 페이지에서 작업했습니다.

https://github.com/user-attachments/assets/b5ee4f73-54a2-4df5-b7b6-6b7a37db0403


## 💬 리뷰 요구사항(선택)
- 포켓몬을 클릭했을때 포켓몬의 고유 번호를 받아오는 형식이라 메인 페이지의 세환님의 코드와 합쳐야 해서 회의때 이야기 해보면 좋을것 같습니다.
- 현재 다음과 이전 버튼으로 모달에서 포켓몬을 변경할 때 모달이 닫히고 열리면서 새로운 포켓몬의 정보를 보여줍니다. 모달이 닫히지않고 정보만 교체 하는 형식이 가능할까요?
- 포켓몬 타입 필터링으로 타입에 관련된 포켓몬 리스트를 보여준 상태에서 모달을 열고 다음과 이전 버튼을 클릭할 떄 타입으로 필터링된 기준에서의 다음과 이전 포켓몬을 어떤식으로 보여줘야 하는지 막힌 상태입니다.
(구현된 다음과 이전 버튼은 현재 번호에서 +1 하거나 -1 하는 형식입니다.)
- 진화 트리에 대한 api는 어떤식으로 가져와야할지 분석중이라 분석이 끝나는대로 추가해서 적용하도록 하겠습니다.

## 🏷️ 연관된 이슈 번호
- #14 

## ✅ 체크리스트:
- [X] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
