### PR TITLE
Feature: Loading 컴포넌트 제작

### DIFF
--- a/src/app/_components/landing/PokemonQuiz.tsx
+++ b/src/app/_components/landing/PokemonQuiz.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import { getRandomNumber, getPokemonRandomImage } from '../../../lib/api/api';
 import classNames from 'classnames';
+import Loading from '@/app/loading';
 
 export default function PokemonQuiz() {
   const [userInput, setUserInput] = useState<string>('');
@@ -50,7 +51,7 @@ export default function PokemonQuiz() {
   }, [quizResult]);
 
   if (isLoading) {
-    return <div>로딩중...</div>;
+    return <Loading />;
   }
 
   if (isError) {

--- a/src/app/_components/landing/PokemonQuiz.tsx
+++ b/src/app/_components/landing/PokemonQuiz.tsx
@@ -5,7 +5,7 @@ import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import { getRandomNumber, getPokemonRandomImage } from '../../../lib/api/api';
 import classNames from 'classnames';
-import Loading from '@/app/loading';
+import RandomPokemonLoading from '../loading/RandomPokemonLoading';
 
 export default function PokemonQuiz() {
   const [userInput, setUserInput] = useState<string>('');
@@ -51,7 +51,7 @@ export default function PokemonQuiz() {
   }, [quizResult]);
 
   if (isLoading) {
-    return <Loading />;
+    return <RandomPokemonLoading />;
   }
 
   if (isError) {

--- a/src/app/_components/loading/RandomPokemon.tsx
+++ b/src/app/_components/loading/RandomPokemon.tsx
@@ -1,0 +1,17 @@
+import Image from 'next/image';
+
+export default function RandomPokemon({ pokemonImgSrc }: { pokemonImgSrc: any }) {
+  return (
+    // 서버 컴포넌트와 클라이언트 컴포넌트 양측에서 모두 사용하기 위해 absolute 속성 사용
+    // 상위에 static 이외의 요소가 없다면 최상위 html 태그가 기준이 됨
+    <div className="absolute flex flex-col h-full w-full justify-center items-center gap-2">
+      {/* 이미지가 없을 때 레이아웃 시프트를 없애기 위함 */}
+      <div className="h-[80px]">
+        {pokemonImgSrc && (
+          <Image className="h-[80px] w-auto" src={pokemonImgSrc} alt="로딩중 포켓몬 이미지" height={80} width={80} />
+        )}
+      </div>
+      <p className="text-xl font-black">loading...</p>
+    </div>
+  );
+}

--- a/src/app/_components/loading/RandomPokemon.tsx
+++ b/src/app/_components/loading/RandomPokemon.tsx
@@ -8,7 +8,14 @@ export default function RandomPokemon({ pokemonImgSrc }: { pokemonImgSrc: any })
       {/* 이미지가 없을 때 레이아웃 시프트를 없애기 위함 */}
       <div className="h-[80px]">
         {pokemonImgSrc && (
-          <Image className="h-[80px] w-auto" src={pokemonImgSrc} alt="로딩중 포켓몬 이미지" height={80} width={80} />
+          <Image
+            className="h-[80px] w-auto"
+            src={pokemonImgSrc}
+            alt="로딩중 포켓몬 이미지"
+            height={80}
+            width={80}
+            unoptimized
+          />
         )}
       </div>
       <p className="text-xl font-black">loading...</p>

--- a/src/app/_components/loading/RandomPokemonLoading.tsx
+++ b/src/app/_components/loading/RandomPokemonLoading.tsx
@@ -1,9 +1,18 @@
 import { getLoadingPokemonImage } from '@/lib/api/api';
 import { useQuery } from '@tanstack/react-query';
 import RandomPokemon from './RandomPokemon';
+import { useMemo } from 'react';
 
 export default function RandomPokemonLoading() {
-  const { data: pokemonImgSrc } = useQuery({ queryKey: ['loading'], queryFn: getLoadingPokemonImage });
+  const { data: pokemonImgSrc } = useQuery({
+    queryKey: ['loading'],
+    queryFn: getLoadingPokemonImage,
+  });
 
-  return <RandomPokemon pokemonImgSrc={pokemonImgSrc} />;
+  // 상위 컴포넌트에서 중복된 useEffect를 사용할 경우, isFetching 도중에 이미지가 바뀌어 버리는 현상이 발생하여,
+  // 마운트 시에만 새로운 데이터를 불러오고, 리렌더링 시에는 기존 데이터를 유지하도록 하기 위한 메모이제이션
+  // staleTime으로 조정하면 해당 시간에 겹칠 경우, 중간에 이미지가 바뀌어버리는 현상이 발생함
+  const memoSrc = useMemo(() => pokemonImgSrc, []);
+
+  return <RandomPokemon pokemonImgSrc={memoSrc} />;
 }

--- a/src/app/_components/loading/RandomPokemonLoading.tsx
+++ b/src/app/_components/loading/RandomPokemonLoading.tsx
@@ -1,0 +1,9 @@
+import { getLoadingPokemonImage } from '@/lib/api/api';
+import { useQuery } from '@tanstack/react-query';
+import RandomPokemon from './RandomPokemon';
+
+export default function RandomPokemonLoading() {
+  const { data: pokemonImgSrc } = useQuery({ queryKey: ['loading'], queryFn: getLoadingPokemonImage });
+
+  return <RandomPokemon pokemonImgSrc={pokemonImgSrc} />;
+}

--- a/src/app/_components/main/PokemonList.tsx
+++ b/src/app/_components/main/PokemonList.tsx
@@ -4,16 +4,23 @@ import monsterBall from '@/images/items/poke-ball.webp';
 import matchTypeToColor from '@/utils/matchTypeToColor';
 import useInfiniteScroll from '@/hooks/useInfinityScroll';
 import usePokemonList from '@/hooks/usePokemonList';
+import RandomPokemonLoading from '../loading/RandomPokemonLoading';
 
 export default function PokemonList() {
-  const { pokemonData, fetchNextPage, hasMore } = usePokemonList();
+  const { pokemonData, fetchNextPage, hasMore, isFetchingNextPage } = usePokemonList();
 
   const { targetRef, saveScrollPosition } = useInfiniteScroll(() => {
     fetchNextPage();
     saveScrollPosition();
   }, hasMore);
+
   return (
     <div className="grid gap-4 pb-10 justify-items-center grid-cols-[repeat(auto-fit,minmax(210px,1fr))] pt-10">
+      {isFetchingNextPage && (
+        <div className="backdrop modal-z-index bg-[rgba(168,216,168,0.9)]">
+          <RandomPokemonLoading />
+        </div>
+      )}
       {pokemonData?.pages.map(pokemonList =>
         pokemonList.map(pokemon => (
           <div

--- a/src/app/_components/modal/Portal.tsx
+++ b/src/app/_components/modal/Portal.tsx
@@ -1,9 +1,11 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+type PortalElementId = 'draggable' | 'modal' | 'loading';
+
 interface PortalProps {
   children: ReactNode;
-  elementId: string;
+  elementId: PortalElementId;
 }
 
 export default function Portal({ children, elementId }: PortalProps) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,8 +16,6 @@ export default function RootLayout({
     <html lang="en">
       <body className="bg-[#A8D8A8]">
         <Providers>
-          {/* 오버레이 로딩 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}
-          <div id="loading" />
           {/* 드래그 가능한 몬스터볼 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}
           <div id="draggable" />
           {/* 모달 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,10 +16,12 @@ export default function RootLayout({
     <html lang="en">
       <body className="bg-[#A8D8A8]">
         <Providers>
-        {/* 드래그 가능한 몬스터볼 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}
-        <div id="draggable" />
-        {/* 모달 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}
-        <div id="modal" />
+          {/* 오버레이 로딩 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}
+          <div id="loading" />
+          {/* 드래그 가능한 몬스터볼 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}
+          <div id="draggable" />
+          {/* 모달 컴포넌트를 렌더링하는 포탈을 열기 위한 엘리먼트 */}
+          <div id="modal" />
           <div>{children}</div>
         </Providers>
       </body>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,24 +1,9 @@
-import { getLoadingImage, getRandomNumber } from '@/lib/api/api';
-import Image from 'next/image';
+import { getLoadingPokemonImage } from '@/lib/api/api';
+import RandomPokemon from './_components/loading/RandomPokemon';
 
 // SSR 과정의 로딩중에 표출되는 로딩 컴포넌트
 export default async function Loading() {
-  const randomNumber = getRandomNumber(1, 649); // 2d live gif가 존재하는 BW 버전 포켓몬까지만 불러옴
-  // 단순 조회용, 매번 랜덤 이미지를 불러오는 것이 목적이므로 쿼리키에 의한 캐시가 의미 없고,
-  // 오히려 prefetchQuery나 useQuery를 사용하는 것이 코드를 복잡하게 만들 수 있기 때문에 사용하지 않음
-  const pokemonImgSrc = await getLoadingImage(randomNumber);
+  const pokemonImgSrc = await getLoadingPokemonImage();
 
-  return (
-    // 서버 컴포넌트와 클라이언트 컴포넌트 양측에서 모두 사용하기 위해 absolute 속성 사용
-    // 상위에 static 이외의 요소가 없다면 최상위 html 태그가 기준이 됨
-    <div className="absolute flex flex-col h-full w-full justify-center items-center gap-2">
-      {/* 이미지가 없을 때 레이아웃 시프트를 없애기 위함 */}
-      <div className="h-[80px]">
-        {pokemonImgSrc && (
-          <Image className="h-[80px] w-auto" src={pokemonImgSrc} alt="로딩중 포켓몬 이미지" height={80} width={80} />
-        )}
-      </div>
-      <p className="text-xl font-black">loading...</p>
-    </div>
-  );
+  return <RandomPokemon pokemonImgSrc={pokemonImgSrc} />;
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,24 @@
+import { getLoadingImage, getRandomNumber } from '@/lib/api/api';
+import Image from 'next/image';
+
+// SSR 과정의 로딩중에 표출되는 로딩 컴포넌트
+export default async function Loading() {
+  const randomNumber = getRandomNumber(1, 649); // 2d live gif가 존재하는 BW 버전 포켓몬까지만 불러옴
+  // 단순 조회용, 매번 랜덤 이미지를 불러오는 것이 목적이므로 쿼리키에 의한 캐시가 의미 없고,
+  // 오히려 prefetchQuery나 useQuery를 사용하는 것이 코드를 복잡하게 만들 수 있기 때문에 사용하지 않음
+  const pokemonImgSrc = await getLoadingImage(randomNumber);
+
+  return (
+    // 서버 컴포넌트와 클라이언트 컴포넌트 양측에서 모두 사용하기 위해 absolute 속성 사용
+    // 상위에 static 이외의 요소가 없다면 최상위 html 태그가 기준이 됨
+    <div className="absolute flex flex-col h-full w-full justify-center items-center gap-2">
+      {/* 이미지가 없을 때 레이아웃 시프트를 없애기 위함 */}
+      <div className="h-[80px]">
+        {pokemonImgSrc && (
+          <Image className="h-[80px] w-auto" src={pokemonImgSrc} alt="로딩중 포켓몬 이미지" height={80} width={80} />
+        )}
+      </div>
+      <p className="text-xl font-black">loading...</p>
+    </div>
+  );
+}

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,7 +1,7 @@
 import getQueryClient from '@/utils/getQueryClient';
 import DraggableMenuTrigger from '../_components/draggableSearchMenu/DraggableMenuTrigger';
 import PokemonList from '../_components/main/PokemonList';
-import { getPokemonAllList } from '@/lib/api/api';
+import { getLoadingPokemonImage, getPokemonAllList } from '@/lib/api/api';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import SearchSection from '../_components/main/SearchSection';
 export default async function MainPage() {
@@ -13,6 +13,9 @@ export default async function MainPage() {
     queryFn: () => getPokemonAllList({ offset: undefined, limit: undefined }),
     initialPageParam: 0,
   });
+
+  // 로딩시 보여줄 랜덤 포켓몬 이미지 prefetch
+  await queryClient.prefetchQuery({ queryKey: ['loading'], queryFn: getLoadingPokemonImage });
 
   const dehydratedState = dehydrate(queryClient);
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import DraggableMenuTrigger from './_components/draggableSearchMenu/DraggableMenuTrigger';
 import PokemonQuiz from './_components/landing/PokemonQuiz';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -10,7 +9,6 @@ export default function Landing() {
   const [queryClient] = useState(() => new QueryClient());
   return (
     <div>
-      <DraggableMenuTrigger />
       <div className="flex flex-col justify-between items-center gap-8 absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] w-full min-h-[500px] sm:min-h-[700px] pb-6 sm:pb-10 max-w-[1200px] rounded-3xl bg-[#F2F4F6] border-4 border-[#ffffff] px-[10px]">
         <div className="w-full mt-[-20px] sm:mt-[-30px]">
           <h1 className="title-line text-2xl sm:text-5xl lg:text-6xl text-center text-[#F9DC42]">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,13 @@
-'use client';
-
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import PokemonQuiz from './_components/landing/PokemonQuiz';
 import Link from 'next/link';
-import { useState } from 'react';
+import { getLoadingPokemonImage } from '@/lib/api/api';
 
-export default function Landing() {
-  const [queryClient] = useState(() => new QueryClient());
+export default async function Landing() {
+  const queryClient = new QueryClient();
+  // 랜덤 포켓몬을 네트워크 요청으로 받아 표출할 로딩용 컴포넌트를 위한 prefetchQuery
+  await queryClient.prefetchQuery({ queryKey: ['loading'], queryFn: getLoadingPokemonImage });
+
   return (
     <div>
       <div className="flex flex-col justify-between items-center gap-8 absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] w-full min-h-[500px] sm:min-h-[700px] pb-6 sm:pb-10 max-w-[1200px] rounded-3xl bg-[#F2F4F6] border-4 border-[#ffffff] px-[10px]">
@@ -22,9 +23,9 @@ export default function Landing() {
         >
           포켓몬 도감
         </Link>
-        <QueryClientProvider client={queryClient}>
+        <HydrationBoundary state={dehydrate(queryClient)}>
           <PokemonQuiz />
-        </QueryClientProvider>
+        </HydrationBoundary>
       </div>
     </div>
   );

--- a/src/hooks/usePokemonList.ts
+++ b/src/hooks/usePokemonList.ts
@@ -5,7 +5,11 @@ import { useState } from 'react';
 const usePokemonList = () => {
   const [hasMore, setHasMore] = useState(true);
 
-  const { data: pokemonData, fetchNextPage } = useSuspenseInfiniteQuery({
+  const {
+    data: pokemonData,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useSuspenseInfiniteQuery({
     queryKey: ['pokemon'],
     queryFn: ({ pageParam }) => getPokemonAllList({ offset: pageParam, limit: 20 }),
     initialPageParam: 0,
@@ -18,6 +22,6 @@ const usePokemonList = () => {
     },
   });
 
-  return { pokemonData, fetchNextPage, hasMore };
+  return { pokemonData, fetchNextPage, hasMore, isFetchingNextPage };
 };
 export default usePokemonList;

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -110,6 +110,12 @@ export const getRandomNumber = (min: number, max: number) => {
   return Math.floor(Math.random() * (max - min + 1) + min);
 };
 
+// 로딩용 랜덤 포켓몬 이미지 생성
+export const getLoadingPokemonImage = async () => {
+  const randomNumber = getRandomNumber(1, 649);
+  return await getLoadingImage(randomNumber);
+};
+
 // 포켓몬 퀴즈 정보(이름, 이미지, 설명)
 export const getPokemonRandomImage = async (number: number, language = 'ko') => {
   const [pokemonData, speciesData] = await Promise.all([fetchPokemonData(number), fetchSpeciesData(number)]);


### PR DESCRIPTION
## ✏️ 작업 내용 요약
>  Loading 컴포넌트 제작

## 📝 작업 내용 설명
- SSR / CSR 따로 로딩 컴포넌트를 구현했습니다.
  현재 api 요청 함수가 내장 fetch 함수를 사용하는 것이 아니라 axios를 사용하고 있으므로,
  캐시 기능이 지원되지 않기 때문에 SSR에서는 단 한번의 요청이 일어나지만,
  CSR측에서 useQuery 의 캐시 관리가 없으면 네트워크 중복 요청이 일어났기 때문입니다.
- SSR 측은 nextjs 프레임워크가 제공하는 loading.tsx를 사용했으며,
CSR측은 prefetchQuery와 useQuery를 사용하여 매 로딩마다 서로 다른 랜덤 포켓몬을 보여줄 수 있도록 하였습니다.
    하지만 데이터를 요청하는 로직이 달라도 렌더링하는 컴포넌트는 같도록 하여 코드 재사용성을 높였습니다.
- CSR 측에서 prefetchQuery를 사용한 이유는, 로딩 화면에서 매번 다른 포켓몬 이미지를 요청해야하기 때문에,
서로 같은 시점에 네트워크 요청을 실행하면 랜덤 포켓몬 이미지 요청과 로딩중인 컴포넌트의 네트워크 요청의
pending 시간이 차이가 나지 않아, 랜덤 포켓몬을 보여주기 전에 로딩이 완료되는 문제가 발생했기 때문입니다.
- 랜덤 포켓몬을 표출하는 컴포넌트를 재사용 가능하도록 만들어 클라이언트 컴포넌트에서도 같은 컴포넌트를 사용합니다.
- CSR 측의 컴포넌트 마운트 시에만 네트워크 요청이 일어나고,
로딩 표출 시에 포켓몬이 바뀌는 일이 없도록 랜덤 넘버에 메모이제이션 처리를 하였습니다.

## 📷 스크린샷

https://github.com/user-attachments/assets/f0cce249-417c-4c87-8cf9-c86bd9099332

## 💬 리뷰 요구사항
> 문제가 발생하거나, 수정할 부분이 있다면 알려주시면 감사하겠습니다!



### 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 로딩 컴포넌트를 테스트하기 위해, prefetch HydrationBoundary 부분과 기존 다른 분들의 코드에 로딩중 컴포넌트가 추가되어 있습니다.
이 부분 고려하여 코드 리뷰 부탁드리겠습니다.

## 🏷️ 연관된 이슈 번호
> [#15 로딩 컴포넌트 제작](#15)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
