### PR TITLE
Refactor: DraggableMenu 내부로 컴포넌트 주입 가능하도록 변경

### DIFF
--- a/src/app/_components/draggableSearchMenu/DraggableMenu.tsx
+++ b/src/app/_components/draggableSearchMenu/DraggableMenu.tsx
@@ -2,13 +2,13 @@
 
 import { motion, useDragControls } from 'framer-motion';
 import MonsterBall from './MonsterBall';
-import { useRef, useState } from 'react';
+import { ReactNode, useRef, useState } from 'react';
 import SearchMenuContainer from './SearchMenuContainer';
 import classNames from 'classnames';
 import Portal from '../modal/Portal';
 import { useToggle } from '@/hooks/useToggle';
 
-export default function DraggableMenuTrigger() {
+export default function DraggableMenu({ children }: { children: ReactNode }) {
   const [isDragging, setIsDragging] = useState(false);
   const { toggleValue, switchToggle, turnOffToggle } = useToggle();
   const dragControls = useDragControls();
@@ -25,7 +25,9 @@ export default function DraggableMenuTrigger() {
   return (
     <Portal elementId="draggable">
       <div ref={constraintsRef} className="backdrop pointer-events-none draggable-z-index">
-        <SearchMenuContainer isOpenMenu={toggleValue} onCloseMenuClick={turnOffToggle} />
+        <SearchMenuContainer isOpenMenu={toggleValue} onCloseMenuClick={turnOffToggle}>
+          {children}
+        </SearchMenuContainer>
         <motion.div
           ref={menuContainer}
           dragControls={dragControls}

--- a/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
+++ b/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
@@ -1,16 +1,18 @@
 import classNames from 'classnames';
-import SearchMenuContent from './SearchMenuContent';
 import Image from 'next/image';
 import defaultPokemonImage from '@/images/pokemon/pikachu.gif';
 import { useHidden } from '@/hooks/useHidden';
 import BackDrop from '../modal/BackDrop';
+import SearchMenuContent from './SearchMenuContent';
+import { ReactNode } from 'react';
 
 interface SearchMenuContainerProps {
   isOpenMenu: boolean;
   onCloseMenuClick: () => void;
+  children: ReactNode;
 }
 
-export default function SearchMenuContainer({ isOpenMenu, onCloseMenuClick }: SearchMenuContainerProps) {
+export default function SearchMenuContainer({ isOpenMenu, onCloseMenuClick, children }: SearchMenuContainerProps) {
   const { isHidden } = useHidden(isOpenMenu);
 
   return (
@@ -37,7 +39,7 @@ export default function SearchMenuContainer({ isOpenMenu, onCloseMenuClick }: Se
                 x
               </button>
               <Image src={defaultPokemonImage} alt="포켓몬 이미지" height={75} width={75} unoptimized priority />
-              <SearchMenuContent />
+              <SearchMenuContent>{children}</SearchMenuContent>
             </div>
           </div>
         </div>

--- a/src/app/_components/draggableSearchMenu/SearchMenuContent.tsx
+++ b/src/app/_components/draggableSearchMenu/SearchMenuContent.tsx
@@ -1,9 +1,9 @@
-export default function SearchMenuContent() {
+import { ReactNode } from 'react';
+
+export default function SearchMenuContent({ children }: { children: ReactNode }) {
   return (
-    <div className="w-72 border rounded-md p-3 bg-white">
-      <section className="flex flex-col items-center">
-        <h4>어떤 포켓몬을 찾아볼까요?</h4>
-      </section>
+    <div className="border rounded-md p-3 bg-white">
+      <>{children}</>
     </div>
   );
 }

--- a/src/app/_components/modal/Portal.tsx
+++ b/src/app/_components/modal/Portal.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-type PortalElementId = 'draggable' | 'modal' | 'loading';
+type PortalElementId = 'draggable' | 'modal';
 
 interface PortalProps {
   children: ReactNode;

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,9 +1,9 @@
 import getQueryClient from '@/utils/getQueryClient';
-import DraggableMenuTrigger from '../_components/draggableSearchMenu/DraggableMenuTrigger';
 import PokemonList from '../_components/main/PokemonList';
 import { getLoadingPokemonImage, getPokemonAllList } from '@/lib/api/api';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import SearchSection from '../_components/main/SearchSection';
+import DraggableMenu from '../_components/draggableSearchMenu/DraggableMenu';
 export default async function MainPage() {
   const queryClient = getQueryClient();
 
@@ -23,7 +23,9 @@ export default async function MainPage() {
       <SearchSection />
       <HydrationBoundary state={dehydratedState}>
         <PokemonList />
-        <DraggableMenuTrigger />
+        <DraggableMenu>
+          <div>내부 컨텐츠</div>
+        </DraggableMenu>
       </HydrationBoundary>
     </div>
   );


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> DraggableMenu 내부로 컴포넌트 주입 가능하도록 변경

## 📝 작업 내용 설명
- DraggableMenuTrigger를 DraggableMenu로 이름 수정
- DraggableMenu 내부에 children으로 모달 내부에 원하는 컴포넌트를 넣을 수 있도록 수정

## 📷 스크린샷
<img width="853" alt="image" src="https://github.com/user-attachments/assets/f43a456b-52c8-4599-9da9-24cb3acb434f">

<img width="453" alt="image" src="https://github.com/user-attachments/assets/5bd688bc-40e9-4469-b439-5044072154f2">

## 💬 리뷰 요구사항(선택)
> 내부에 children으로 넣는 것으로 구현해보았는데, 혹시 더 좋은 방법이 있다면 알려주십셔!

## 🏷️ 연관된 이슈 번호
> #2

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
