### PR TITLE
Feature: 포켓몬 카드의 몬스터볼을 클릭하면 로컬 스토리지에 내 포켓몬 저장하는 기능 구현

### DIFF
--- a/src/app/_components/draggableSearchMenu/DraggableMenu.tsx
+++ b/src/app/_components/draggableSearchMenu/DraggableMenu.tsx
@@ -2,15 +2,15 @@
 
 import { motion, useDragControls } from 'framer-motion';
 import MonsterBall from './MonsterBall';
-import { ReactNode, useRef, useState } from 'react';
+import { ReactElement, useRef, useState } from 'react';
 import SearchMenuContainer from './SearchMenuContainer';
 import classNames from 'classnames';
 import Portal from '../modal/Portal';
 import { useToggle } from '@/hooks/useToggle';
 
-export default function DraggableMenu({ children }: { children: ReactNode }) {
+export default function DraggableMenu({ children }: { children: ReactElement }) {
   const [isDragging, setIsDragging] = useState(false);
-  const { toggleValue, switchToggle, turnOffToggle } = useToggle();
+  const { toggleValue: isMenuOpen, switchToggle, turnOffToggle } = useToggle();
   const dragControls = useDragControls();
   const constraintsRef = useRef(null);
   const menuContainer = useRef(null);
@@ -25,7 +25,7 @@ export default function DraggableMenu({ children }: { children: ReactNode }) {
   return (
     <Portal elementId="draggable">
       <div ref={constraintsRef} className="backdrop pointer-events-none draggable-z-index">
-        <SearchMenuContainer isOpenMenu={toggleValue} onCloseMenuClick={turnOffToggle}>
+        <SearchMenuContainer isOpenMenu={isMenuOpen} onCloseMenuClick={turnOffToggle}>
           {children}
         </SearchMenuContainer>
         <motion.div

--- a/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
+++ b/src/app/_components/draggableSearchMenu/SearchMenuContainer.tsx
@@ -39,7 +39,7 @@ export default function SearchMenuContainer({ isOpenMenu, onCloseMenuClick, chil
                 x
               </button>
               <Image src={defaultPokemonImage} alt="포켓몬 이미지" height={75} width={75} unoptimized priority />
-              <SearchMenuContent>{children}</SearchMenuContent>
+              <SearchMenuContent searchMenuOff={onCloseMenuClick}>{children}</SearchMenuContent>
             </div>
           </div>
         </div>

--- a/src/app/_components/draggableSearchMenu/SearchMenuContent.tsx
+++ b/src/app/_components/draggableSearchMenu/SearchMenuContent.tsx
@@ -1,9 +1,29 @@
-import { ReactNode } from 'react';
+import { createContext, ReactNode, useContext } from 'react';
 
-export default function SearchMenuContent({ children }: { children: ReactNode }) {
+interface SearchMenuContentProps {
+  searchMenuOff: () => void;
+  children: ReactNode;
+}
+interface SearchMenuContentContextValue {
+  searchMenuOff: () => void;
+}
+
+const SearchMenuContentContext = createContext<SearchMenuContentContextValue | undefined>(undefined);
+
+export default function SearchMenuContent({ searchMenuOff, children }: SearchMenuContentProps) {
   return (
-    <div className="border rounded-md p-3 bg-white">
-      <>{children}</>
-    </div>
+    <SearchMenuContentContext.Provider value={{ searchMenuOff }}>
+      <div className="border rounded-md p-3 bg-white">{children}</div>
+    </SearchMenuContentContext.Provider>
   );
 }
+
+export const useSearchMenuOff = () => {
+  const context = useContext(SearchMenuContentContext);
+
+  if (!context) {
+    throw new Error('반드시 DraggableMenu의 자식 컴포넌트로 렌더링 되는 요소에서만 사용해야 합니다.');
+  }
+
+  return context;
+};

--- a/src/app/_components/main/PokePicker.tsx
+++ b/src/app/_components/main/PokePicker.tsx
@@ -1,0 +1,58 @@
+import classNames from 'classnames';
+import Image from 'next/image';
+import monsterBall from '@/images/items/poke-ball.webp';
+import { useToastAction } from '@/stores/actions/useToastAction';
+import { useEffect, useState } from 'react';
+
+interface PokePickerProps {
+  id: number;
+  name: string;
+}
+
+const getPokebox = () => {
+  const storage = localStorage.getItem('pokebox');
+  return storage ? (JSON.parse(storage) as number[]) : null;
+};
+
+export default function PokePicker({ id, name }: PokePickerProps) {
+  const { addToast } = useToastAction();
+  const [isPicked, setIsPicked] = useState<boolean>(false);
+
+  const handlePickerClick = () => {
+    const pokebox = getPokebox();
+    if (pokebox) {
+      if (isPicked) {
+        localStorage.setItem('pokebox', JSON.stringify(pokebox.filter(v => v !== id)));
+        addToast({ type: 'error', message: `바이바이, ${name}!` });
+        setIsPicked(false);
+      } else {
+        localStorage.setItem('pokebox', JSON.stringify([...pokebox, id]));
+        addToast({ type: 'success', message: `${name}이(가) 포켓박스에 추가되었다!` });
+        setIsPicked(true);
+      }
+    }
+  };
+
+  useEffect(() => {
+    const pokebox = getPokebox();
+    if (pokebox) {
+      const isPickedPokemon = pokebox.find(v => v === id);
+      if (isPickedPokemon) {
+        setIsPicked(true);
+      } else {
+        setIsPicked(false);
+      }
+    } else {
+      localStorage.setItem('pokebox', JSON.stringify([]));
+    }
+  }, [isPicked]);
+
+  return (
+    <button
+      onClick={handlePickerClick}
+      className={classNames('w-[30px] h-[30px] absolute top-[21px] right-2', isPicked ? 'opacity-100' : 'opacity-50')}
+    >
+      <Image src={monsterBall} alt="즐겨찾기" width={30} height={30} />
+    </button>
+  );
+}

--- a/src/app/_components/main/PokemonList.tsx
+++ b/src/app/_components/main/PokemonList.tsx
@@ -1,10 +1,9 @@
 import { PokemonInfo } from '@/lib/api/type';
 import { InfiniteData } from '@tanstack/react-query';
 import Image from 'next/image';
-import monsterBall from '@/images/items/poke-ball.webp';
 import koreanTypeToColor from '@/utils/koreanTypeToColor';
 import { MutableRefObject } from 'react';
-import classNames from 'classnames';
+import PokePicker from './PokePicker';
 
 interface PokemonListProps {
   pokemonData: InfiniteData<PokemonInfo[] | undefined, unknown> | undefined;
@@ -24,9 +23,7 @@ export default function PokemonList({ pokemonData, targetRef }: PokemonListProps
               <span className="absolute top-1 text-xs opacity-30">No.{pokemon.id}</span>
               <span className="flex pt-1.5 justify-center w-full">{pokemon.name}</span>
 
-              <button className={classNames('w-[30px] opacity-50 h-[30px] absolute top-[21px] right-2')}>
-                <Image src={monsterBall} alt="즐겨찾기" fill />
-              </button>
+              <PokePicker id={pokemon.id} name={pokemon.name} />
 
               <Image src={pokemon.image} alt="포켓몬 이미지" width={50} height={50} />
 

--- a/src/app/_components/toast/Toast.tsx
+++ b/src/app/_components/toast/Toast.tsx
@@ -32,24 +32,51 @@ export default function Toast({ id, type, message }: ToastProps) {
 
   return (
     <div
-      className={classNames('px-4 py-3 shadow-md rounded-lg max-w-[90dvw] text-lg font-bold', {
-        'border border-green-400 bg-green-100 text-green-400': type === 'success',
-        'border border-yellow-400 bg-white text-yellow-400': type === 'warn',
-        'border border-red-400 bg-red-100 text-red-400': type === 'error',
+      className={classNames('w-fit max-w-[90dvw] px-4 py-3 shadow-md rounded-lg text-xs font-bold md:text-lg', {
+        'border border-green-500 bg-green-50 text-green-500': type === 'success',
+        'border border-yellow-500 bg-white text-yellow-500': type === 'warn',
+        'border border-red-500 bg-red-50 text-red-500': type === 'error',
         'animate-fadeIn': !isExit,
         'animate-fadeOut': isExit,
       })}
     >
       <div className="flex items-center w-full gap-1.5">
         {ToastIcon[type]}
-        <p className="overflow-hidden text-ellipsis whitespace-nowrap">{message}</p>
+        <div className="overflow-hidden text-ellipsis whitespace-nowrap">{message}</div>
       </div>
     </div>
   );
 }
 
 const ToastIcon: Record<ToastTypes, ReactNode> = {
-  success: <Image src={iconSuccess} alt="성공 메시지 아이콘" height={25} width={25} priority />,
-  warn: <Image src={iconWarn} alt="경고 메시지 아이콘" height={25} width={25} className="filter-yellow" priority />,
-  error: <Image src={iconError} alt="실패 메시지 아이콘" height={25} width={25} priority />,
+  success: (
+    <Image
+      src={iconSuccess}
+      alt="성공 메시지 아이콘"
+      height={25}
+      width={25}
+      className="h-5 w-5 md:h-[25px] md:w-[25px]"
+      priority
+    />
+  ),
+  warn: (
+    <Image
+      src={iconWarn}
+      alt="경고 메시지 아이콘"
+      height={25}
+      width={25}
+      className="filter-yellow h-5 w-5 md:h-[25px] md:w-[25px]"
+      priority
+    />
+  ),
+  error: (
+    <Image
+      src={iconError}
+      alt="실패 메시지 아이콘"
+      className="h-5 w-5 md:h-[25px] md:w-[25px]"
+      height={25}
+      width={25}
+      priority
+    />
+  ),
 };

--- a/src/app/_components/toast/ToastList.tsx
+++ b/src/app/_components/toast/ToastList.tsx
@@ -7,7 +7,7 @@ export default function ToastList() {
   const toastList = useToastStore(state => state.toastList);
 
   return (
-    <div className="fixed top-[200px] left-1/2 -translate-x-1/2 toast-z-index flex flex-col items-center gap-5">
+    <div className="fixed top-[200px] left-1/2 -translate-x-1/2 toast-z-index flex flex-col items-center gap-5 w-full">
       {toastList.map(toast => (
         <Toast key={toast.id} id={toast.id} type={toast.type} message={toast.message} />
       ))}

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -6,8 +6,8 @@ export const useToastStore = create<ToastStore>(set => ({
   action: {
     addToast: newToast => {
       set(prevState => {
-        // 토스트 개수 3개 이하로 제한
-        if (prevState.toastList.length >= 3) {
+        // 토스트 개수 20개 이하로 제한
+        if (prevState.toastList.length >= 20) {
           return { toastList: [...prevState.toastList] };
         }
         return { toastList: [{ ...newToast, id: Date.now().toString() }, ...prevState.toastList] };

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -23,7 +23,7 @@
     z-index: 3;
   }
   .toast-z-index {
-    z-index: 4;
+    z-index: 2;
   }
 }
 


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 포켓몬 카드의 몬스터볼을 클릭하면 로컬 스토리지에 내 포켓몬 저장하는 기능 구현 및 DraggableMenu, Toast 수정

## 📝 작업 내용 설명
- DraggableMenu의 children로 들어가는 요소 내부에서 메뉴를 닫을 수 있도록 context api를 활용하여 커스텀 훅을 제작해두었습니다.
  -  DraggableMenu의 children인 컴포넌트에서 useSearchMenuOff 훅을 사용하여, searchMenuOff 메서드를 꺼내면 됩니다.
- 도감 페이지의 포켓몬 카드 내부의 몬스터볼을 클릭하면 해당 포켓몬의 id가 pokebox라는 이름으로 로컬 스토리지에,
id number 배열로 저장됩니다.
- 한 번 누르면 몬스터볼의 투명도가 사라지며, 추가 문구 토스트가 띄워지고,
한 번 더 누르면 몬스터볼이 반투명해지고, 삭제 문구 토스트가 띄워집니다.
- 토스트 개수 제한을 20개로 하고, 시안성 확보를 위해 폰트 색상을 진하게 하고, 모바일 화면에서 폰트 사이즈도 줄여두었습니다.

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/3abb77cc-5877-452d-903d-970562dc98de

## 💬 리뷰 요구사항(선택)
> 필요한 부분이 있거나 개선이 필요하다면 알려주세요!

## 🏷️ 연관된 이슈 번호
[#36 내 포켓몬 저장 기능 구현](#36)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
