### PR TITLE
Feature: 포켓몬 즐겨찾기 로컬스토리지 연동

### DIFF
--- a/src/app/_components/landing/PokemonQuiz.tsx
+++ b/src/app/_components/landing/PokemonQuiz.tsx
@@ -118,7 +118,7 @@ export default function PokemonQuiz() {
             <button
               type="submit"
               ref={buttonRef}
-              className="h-10 min-w-[56px] px-3 rounded-lg shadow-[2px_4px_4px_rgba(0,0,0,0.2)] bg-white focus-visible:outline-none hover:bg-gray-200"
+              className="h-10 px-3 rounded-lg shadow-[2px_4px_4px_rgba(0,0,0,0.2)] bg-white focus-visible:outline-none hover:bg-gray-200"
             >
               {quizResult ? retryText : submitText}
             </button>
@@ -126,7 +126,7 @@ export default function PokemonQuiz() {
             {quizResult && (
               <Link
                 href="/main"
-                className="h-10 leading-10 min-w-[56px] px-3 rounded-lg shadow-[2px_4px_4px_rgba(0,0,0,0.2)] bg-white focus-visible:outline-none hover:bg-gray-200"
+                className="h-10 leading-10 px-3 rounded-lg shadow-[2px_4px_4px_rgba(0,0,0,0.2)] bg-white focus-visible:outline-none hover:bg-gray-200"
               >
                 {language === 'ko' ? '포켓몬 도감' : 'Pokedex'}
               </Link>

--- a/src/app/_components/main/PokedexMain.tsx
+++ b/src/app/_components/main/PokedexMain.tsx
@@ -81,9 +81,9 @@ export default function PokedexMain() {
         <PokemonList pokemonData={allPokemonData} targetRef={targetRef} />
       )}
       {!!activedTypeNum && searchedPokemon === null && (
-        <PokemonList pokemonData={typePokemonData} targetRef={typeTargetRef} />
+        <PokemonList pokemonData={typePokemonData} targetRef={typeTargetRef} carousel={false} />
       )}
-      {searchedPokemon && <PokemonList pokemonData={searchedPokemon} />}
+      {searchedPokemon && <PokemonList pokemonData={searchedPokemon} carousel={false} />}
       {searchedPokemon === false && <div>없음</div>}
       <DraggableMenu>
         <SearchSection

--- a/src/app/_components/main/PokemonList.tsx
+++ b/src/app/_components/main/PokemonList.tsx
@@ -12,9 +12,10 @@ import PokePicker from './PokePicker';
 interface PokemonListProps {
   pokemonData: InfiniteData<PokemonInfo[] | undefined, unknown> | undefined;
   targetRef?: MutableRefObject<HTMLDivElement | null>;
+  carousel?: boolean;
 }
 
-export default function PokemonList({ pokemonData, targetRef }: PokemonListProps) {
+export default function PokemonList({ pokemonData, targetRef, carousel }: PokemonListProps) {
   const { language } = useLanguageStore();
   const [pokemonId, setPokemonId] = useState<number>(0);
   const { toggleValue, switchToggle, turnOffToggle } = useToggle();
@@ -31,7 +32,7 @@ export default function PokemonList({ pokemonData, targetRef }: PokemonListProps
   return (
     <div className="grid gap-4 pb-10 justify-items-center grid-cols-[repeat(auto-fit,minmax(210px,1fr))] pt-10">
       <ModalFrame isOpenModal={toggleValue} closeModal={turnOffToggle} backdropBgColor="#000000">
-        <PokemonModal turnOffToggle={turnOffToggle} pokemonNumber={pokemonId} />
+        <PokemonModal turnOffToggle={turnOffToggle} pokemonNumber={pokemonId} carousel={carousel} />
       </ModalFrame>
       {pokemonData?.pages.map(pokemonList =>
         pokemonList?.map(pokemon =>

--- a/src/app/_components/pokemonModal/PokemonModal.tsx
+++ b/src/app/_components/pokemonModal/PokemonModal.tsx
@@ -12,9 +12,10 @@ import { useLanguageStore } from '@/stores/useLanguageStore';
 interface PokemonModalProps {
   turnOffToggle: () => void;
   pokemonNumber: number;
+  carousel?: boolean;
 }
 
-export default function PokemonModal({ turnOffToggle, pokemonNumber }: PokemonModalProps) {
+export default function PokemonModal({ turnOffToggle, pokemonNumber, carousel }: PokemonModalProps) {
   const { language } = useLanguageStore();
   const [tabActive, setTabActive] = useState<string>('info');
   const [shiny, setShiny] = useState<boolean>(false);
@@ -43,10 +44,10 @@ export default function PokemonModal({ turnOffToggle, pokemonNumber }: PokemonMo
     return <div>에러...</div>;
   }
   return (
-    <div className="relative w-screen max-w-[90%] sm:max-w-[500px] md:max-w-[700px] h-[75vh] bg-[#F0F0F0] rounded-2xl mx-auto p-2 md:p-4">
-      <div className="flex flex-col justify-between h-full bg-[#79C9FA] rounded-2xl">
+    <div className="relative w-screen max-w-[90%] sm:max-w-[500px] md:max-w-[700px] h-[75vh] max-h-[700px] bg-[#F0F0F0] rounded-2xl mx-auto p-2 md:p-4">
+      <div className="flex flex-col justify-between h-full bg-[#79C9FA] rounded-2xl overflow-y-auto">
         <ModalTitle pokemonData={data} onTurnOffToggle={turnOffToggle} language={language} />
-        <ModalImage pokemonData={data} number={number} setNumber={setNumber} shiny={shiny} />
+        <ModalImage pokemonData={data} number={number} setNumber={setNumber} shiny={shiny} carousel={carousel} />
         <div>
           <ModalTabMenu
             tabActive={tabActive}

--- a/src/app/_components/pokemonModal/components/FavoritePokemon.tsx
+++ b/src/app/_components/pokemonModal/components/FavoritePokemon.tsx
@@ -1,16 +1,27 @@
-import pokemonImage from '@/images/pokemon/pikachu.gif';
-import monsterBall from '@/images/items/poke-ball.webp';
 import Image from 'next/image';
+import PokePicker from '../../main/PokePicker';
 
-export default function FavoritePokemon() {
+export default function FavoritePokemon({
+  name,
+  image,
+  id,
+  onHandleRefreshData,
+}: {
+  name: string;
+  image: string;
+  id: number;
+  onHandleRefreshData: (id: number) => void;
+}) {
   return (
     <div className="flex flex-col items-center">
-      <Image src={pokemonImage} width={80} height={80} alt="포켓몬 이미지" />
+      <div className="w-[110px] h-[110px] sm:w-[120px] sm:h-[120px] relative">
+        <Image src={image} className="object-contain py-5" fill sizes="100vw, 100vw" alt="포켓몬 이미지" />
+      </div>
       <div className="flex items-center mt-2">
-        <h3 className="outline-text text-sm sm:text-base md:text-lg">피카츄</h3>
-        <button>
-          <Image className="opacity-100" width={30} height={30} src={monsterBall} alt="즐겨찾기" />
-        </button>
+        <h3 className="outline-text text-sm sm:text-base md:text-lg">{name}</h3>
+        <div className="flex items-center favorite-modal-important" onClick={() => onHandleRefreshData(Number(id))}>
+          <PokePicker id={id} name={name} />
+        </div>
       </div>
     </div>
   );

--- a/src/app/_components/pokemonModal/components/ModalImage.tsx
+++ b/src/app/_components/pokemonModal/components/ModalImage.tsx
@@ -6,40 +6,45 @@ interface ModalImageProps {
   number: number;
   setNumber: React.Dispatch<React.SetStateAction<number>>;
   shiny: boolean;
+  carousel: boolean | undefined;
 }
 
-export default function ModalImage({ pokemonData, number, setNumber, shiny }: ModalImageProps) {
+export default function ModalImage({ pokemonData, number, setNumber, shiny, carousel = true }: ModalImageProps) {
   const pokemonImage = shiny ? pokemonData?.shiny : pokemonData?.image;
   return (
     <>
-      {/* 이전 버튼 */}
-      <button
-        type="button"
-        className={classNames(
-          'absolute top-[50%] translate-y-[-50%] left-7 w-10 h-10 pr-1 text-lg bg-[#D9D9D9] rounded-full z-10',
-          number !== 1 && 'hover:scale-110 hover:bg-white',
-        )}
-        onClick={() => {
-          setNumber(prev => prev - 1);
-        }}
-        disabled={number === 1}
-      >
-        〈
-      </button>
-      {/* 다음 버튼 */}
-      <button
-        type="button"
-        className={classNames(
-          'absolute top-[50%] translate-y-[-50%] right-7 w-10 h-10 pl-1 text-lg bg-[#D9D9D9] rounded-full transition-all z-10',
-          number !== 1025 && 'hover:scale-110 hover:bg-white',
-        )}
-        onClick={() => {
-          setNumber(prev => prev + 1);
-        }}
-        disabled={number === 1025}
-      >
-        〉
-      </button>
+      {carousel && (
+        <>
+          {/* 이전 버튼 */}
+          <button
+            type="button"
+            className={classNames(
+              'absolute top-[50%] translate-y-[-50%] left-7 w-10 h-10 pr-1 text-lg bg-[#D9D9D9] rounded-full z-10',
+              number !== 1 && 'hover:scale-110 hover:bg-white',
+            )}
+            onClick={() => {
+              setNumber(prev => prev - 1);
+            }}
+            disabled={number === 1}
+          >
+            〈
+          </button>
+          {/* 다음 버튼 */}
+          <button
+            type="button"
+            className={classNames(
+              'absolute top-[50%] translate-y-[-50%] right-7 w-10 h-10 pl-1 text-lg bg-[#D9D9D9] rounded-full transition-all z-10',
+              number !== 1025 && 'hover:scale-110 hover:bg-white',
+            )}
+            onClick={() => {
+              setNumber(prev => prev + 1);
+            }}
+            disabled={number === 1025}
+          >
+            〉
+          </button>
+        </>
+      )}
       <div className="relative flex justify-center">
         <Image
           src={pokemonImage || `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/items/poke-ball.png`}

--- a/src/app/_components/pokemonModal/components/ModalTabContent.tsx
+++ b/src/app/_components/pokemonModal/components/ModalTabContent.tsx
@@ -10,7 +10,7 @@ interface ModalTabContentProps {
 
 export default function ModalTabContent({ pokemonData, tabActive, language }: ModalTabContentProps) {
   return (
-    <div className="flex flex-col justify-between w-full h-[180px] sm:h-[150px] bg-black bg-opacity-50 rounded-b-2xl px-3 py-2 text-sm sm:text-base text-white">
+    <div className="flex flex-col justify-between w-full h-[180px] sm:h-[155px] bg-black bg-opacity-50 rounded-b-2xl px-3 py-2 text-sm sm:text-base text-white">
       {tabActive === 'info' && (
         <>
           <p className="break-keep">{pokemonData?.flavor}</p>

--- a/src/app/_components/pokemonModal/components/ModalTitle.tsx
+++ b/src/app/_components/pokemonModal/components/ModalTitle.tsx
@@ -1,7 +1,6 @@
-import monsterBall from '@/images/items/poke-ball.webp';
-import Image from 'next/image';
 import koreanTypeToColor from '@/utils/koreanTypeToColor';
 import { LanguageTypes } from '@/types/language';
+import PokePicker from '../../main/PokePicker';
 
 interface ModalTitleProps {
   pokemonData?: any;
@@ -14,22 +13,22 @@ export default function ModalTitle({ pokemonData, onTurnOffToggle, modalTitle, l
   const formattedId = pokemonData ? String(pokemonData.id).padStart(3, '0') : '000';
   return (
     <div>
-      <div className="flex items-center justify-center relative pt-5 mb-5">
+      <div className="flex items-center justify-center gap-1 relative pt-5 mb-5">
         <h2 className="title-line !font-Galmuri9 text-center text-[#F9DC42] text-2xl md:text-4xl">
           {modalTitle ? modalTitle : `#${formattedId} ${pokemonData?.name}`}
         </h2>
         {modalTitle === undefined && (
-          <button>
-            <Image className="opacity-50" width={50} height={50} src={monsterBall} alt="즐겨찾기" />
-          </button>
+          <div className="flex items-center detail-modal-important pt-[5px]">
+            <PokePicker id={pokemonData?.id} name={pokemonData?.name} />
+          </div>
         )}
 
-        <button type="button" className="absolute top-5 right-5 text-2xl" onClick={onTurnOffToggle}>
+        <button type="button" className="absolute top-[22px] right-5 text-2xl" onClick={onTurnOffToggle}>
           x
         </button>
       </div>
       <div className="flex justify-center items-center gap-1 sm:gap-3">
-        {pokemonData?.typeList.map((type: any) => {
+        {pokemonData?.typeList?.map((type: any) => {
           return (
             <button
               type="button"

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -21,7 +21,7 @@ export default async function MainPage() {
 
   const dehydratedState = dehydrate(queryClient);
   return (
-    <div className="flex flex-col justify-between relative items-center gap-8 m-auto mt-10 w-full min-h-[500px] sm:min-h-[700px] pb-6 sm:pb-10 max-w-[1200px] rounded-3xl bg-[#F2F4F6] border-4 border-[#ffffff] px-[10px]">
+    <div className="flex flex-col justify-between relative items-center gap-20 m-auto mt-10 w-full min-h-[500px] sm:min-h-[700px] pb-6 sm:pb-10 max-w-[1200px] rounded-3xl bg-[#F2F4F6] border-4 border-[#ffffff] px-[10px]">
       <MainTitle />
       <QuizButton />
       <div className="flex flex-col w-full">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ export default async function Landing() {
   await queryClient.prefetchQuery({ queryKey: [LOADING_QUERY_KEY], queryFn: getLoadingPokemonImage });
 
   return (
-    <div className="flex justify-center items-center w-screen h-screen px-3 sm:px-5">
+    <div className="flex justify-center items-center w-full h-screen">
       <div className="relative flex flex-col justify-between items-center gap-8 w-full min-h-[500px] sm:min-h-[700px] pb-6 sm:pb-10 max-w-[1200px] rounded-3xl bg-[#F2F4F6] border-4 border-[#ffffff] px-[10px]">
         <LandingTitle />
         <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -47,3 +47,34 @@
     -1px 1px 0 #ffffff;
   color: #000000; /* 텍스트 색상 */
 }
+
+.detail-modal-important button {
+  position: relative !important;
+  right: auto !important;
+  top: auto !important;
+  width: 50px !important;
+  height: 50px !important;
+}
+
+.detail-modal-important button img {
+  width: 50px !important;
+  height: 50px !important;
+}
+
+@media (max-width: 768px) {
+  .detail-modal-important button {
+    width: 35px !important;
+    height: 35px !important;
+  }
+
+  .detail-modal-important button img {
+    width: 35px !important;
+    height: 35px !important;
+  }
+}
+
+.favorite-modal-important button {
+  position: relative !important;
+  right: auto !important;
+  top: auto !important;
+}


### PR DESCRIPTION
## ✏️ 작업 내용 요약
- 로컬스토리지에 저장된 포켓몬 즐겨찾기 연동

## 📝 작업 내용 설명
### Feature
- 로컬스토리지에 저장된 포켓몬 고유 id를 가져와서 각각 api를 호출하여 이름과 이미지를 노출합니다.
- PokePicker의 사이즈와 position의 위치를 모달전용으로 css를 추가했습니다.
- 텍스트와 타입에 대한 검색 결과의 포켓몬 모달에서 캐러셀을 미노출했습니다.

### Refactor
- 랜딩 페이지 좌우 여백 오류 수정

## 📷 스크린샷 (선택)
https://github.com/user-attachments/assets/6cb149a1-9e61-4e73-aa03-271fdb11260a


## 💬 리뷰 요구사항(선택)


## 🏷️ 연관된 이슈 번호
- #39 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
