### PR TITLE
Featuer: 포케피커 호버링 및 추가 효과 및 드래거블 메뉴 스타일 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "party-js": "^2.2.0",
         "react": "^18",
         "react-dom": "^18",
+        "react-tooltip": "^5.28.0",
         "sharp": "^0.33.5",
         "zustand": "^5.0.0-rc.2"
       },
@@ -112,6 +113,28 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -4501,6 +4524,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.0.tgz",
+      "integrity": "sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "es-hangul": "^2.2.3",
         "framer-motion": "^11.9.0",
         "next": "14.2.13",
+        "party-js": "^2.2.0",
         "react": "^18",
         "react-dom": "^18",
         "sharp": "^0.33.5",
@@ -4136,6 +4137,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/party-js": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/party-js/-/party-js-2.2.0.tgz",
+      "integrity": "sha512-50hGuALCpvDTrQLPQ1fgUgxKIWAH28ShVkmeK/3zhO0YJyCqkhrZhQEkWPxDYLvbFJ7YAXyROmFEu35gKpZLtQ=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "es-hangul": "^2.2.3",
     "framer-motion": "^11.9.0",
     "next": "14.2.13",
+    "party-js": "^2.2.0",
     "react": "^18",
     "react-dom": "^18",
     "sharp": "^0.33.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "party-js": "^2.2.0",
     "react": "^18",
     "react-dom": "^18",
+    "react-tooltip": "^5.28.0",
     "sharp": "^0.33.5",
     "zustand": "^5.0.0-rc.2"
   },

--- a/src/app/_components/draggableSearchMenu/DraggableMenu.tsx
+++ b/src/app/_components/draggableSearchMenu/DraggableMenu.tsx
@@ -4,7 +4,6 @@ import { motion, useDragControls } from 'framer-motion';
 import MonsterBall from './MonsterBall';
 import { ReactElement, useRef, useState } from 'react';
 import SearchMenuContainer from './SearchMenuContainer';
-import classNames from 'classnames';
 import Portal from '../modal/Portal';
 import { useToggle } from '@/hooks/useToggle';
 
@@ -40,15 +39,16 @@ export default function DraggableMenu({ children }: { children: ReactElement }) 
           dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }} // 드래그 요소가 경계를 벗어날 때 튕겨서 돌아오는 효과
           dragElastic={0.5} // 경계 구간에 얼마나 들어갈 수 있는 지 설정
           style={{ touchAction: 'none' }} // 모바일에서 터치 가능하려면 넣어야 하는 설정
+          initial={{ x: 0, y: 100, scale: 0 }} // 초기 위치 및 크기
+          animate={{ scale: 1 }} // 애니메이션이 끝날 때 크기를 1로 설정
+          transition={{ duration: 0.5 }} // 애니메이션 시간 0.5초
+          whileHover={{
+            scale: 1.1,
+            cursor: 'pointer',
+          }}
+          whileTap={{ scale: 0.9, cursor: 'grab' }}
         >
-          <div className="flex gap-5">
-            <article
-              onClick={handleMenuDisplayClick}
-              className={classNames('hover:cursor-pointer', isDragging && 'hover:cursor-grab')}
-            >
-              <MonsterBall />
-            </article>
-          </div>
+          <MonsterBall onClick={handleMenuDisplayClick} />
         </motion.div>
       </div>
     </Portal>

--- a/src/app/_components/draggableSearchMenu/MonsterBall.tsx
+++ b/src/app/_components/draggableSearchMenu/MonsterBall.tsx
@@ -1,16 +1,24 @@
 import Image from 'next/image';
 import pokeBall from '@/images/items/poke-ball.webp';
+import { Tooltip } from 'react-tooltip';
 
-export default function MonsterBall() {
+interface MonsterBallProps {
+  onClick: () => void;
+}
+
+export default function MonsterBall({ onClick }: MonsterBallProps) {
   return (
-    <div className="h-10 w-10 flex justify-center items-center border rounded-md shadow-md bg-white">
-      <Image
-        className="active:pointer-events-none hover:animate-wobbleHorBottom"
-        src={pokeBall}
-        alt="몬스터볼 이미지"
-        height={30}
-        width={30}
-      />
-    </div>
+    <>
+      <div
+        onClick={onClick}
+        id="monsterBall"
+        className="h-[65px] w-[65px] flex justify-center items-center rounded-full animate-wobbleHorBottom hover:animate-none"
+      >
+        <Image className="active:pointer-events-none " src={pokeBall} alt="몬스터볼 이미지" height={60} width={60} />
+      </div>
+      <Tooltip anchorSelect="#monsterBall" place="top">
+        가랏, 몬스터볼!
+      </Tooltip>
+    </>
   );
 }

--- a/src/app/_components/loading/RandomPokemon.tsx
+++ b/src/app/_components/loading/RandomPokemon.tsx
@@ -1,6 +1,7 @@
+import { StaticImport } from 'next/dist/shared/lib/get-img-props';
 import Image from 'next/image';
 
-export default function RandomPokemon({ pokemonImgSrc }: { pokemonImgSrc: any }) {
+export default function RandomPokemon({ pokemonImgSrc }: { pokemonImgSrc: string | StaticImport }) {
   return (
     // 서버 컴포넌트와 클라이언트 컴포넌트 양측에서 모두 사용하기 위해 absolute 속성 사용
     // 상위에 static 이외의 요소가 없다면 최상위 html 태그가 기준이 됨

--- a/src/app/_components/main/PokePicker.tsx
+++ b/src/app/_components/main/PokePicker.tsx
@@ -30,7 +30,7 @@ export default function PokePicker({ id, name }: PokePickerProps) {
         localStorage.setItem('pokebox', JSON.stringify([...pokebox, id]));
         party.sparkles(event.target as HTMLButtonElement, {
           count: 20,
-          speed: 120,
+          speed: 80,
           size: party.variation.range(0.8, 1.2),
         });
         addToast({ type: 'success', message: `${name}이(가) 포켓박스에 추가되었다!` });

--- a/src/app/_components/main/PokePicker.tsx
+++ b/src/app/_components/main/PokePicker.tsx
@@ -2,7 +2,8 @@ import classNames from 'classnames';
 import Image from 'next/image';
 import monsterBall from '@/images/items/poke-ball.webp';
 import { useToastAction } from '@/stores/actions/useToastAction';
-import { useEffect, useState } from 'react';
+import { MouseEvent, useEffect, useState } from 'react';
+import party from 'party-js';
 
 interface PokePickerProps {
   id: number;
@@ -18,7 +19,7 @@ export default function PokePicker({ id, name }: PokePickerProps) {
   const { addToast } = useToastAction();
   const [isPicked, setIsPicked] = useState<boolean>(false);
 
-  const handlePickerClick = () => {
+  const handlePickerClick = (event: MouseEvent<HTMLButtonElement>) => {
     const pokebox = getPokebox();
     if (pokebox) {
       if (isPicked) {
@@ -27,6 +28,11 @@ export default function PokePicker({ id, name }: PokePickerProps) {
         setIsPicked(false);
       } else {
         localStorage.setItem('pokebox', JSON.stringify([...pokebox, id]));
+        party.sparkles(event.target as HTMLButtonElement, {
+          count: 20,
+          speed: 120,
+          size: party.variation.range(0.8, 1.2),
+        });
         addToast({ type: 'success', message: `${name}이(가) 포켓박스에 추가되었다!` });
         setIsPicked(true);
       }
@@ -50,7 +56,10 @@ export default function PokePicker({ id, name }: PokePickerProps) {
   return (
     <button
       onClick={handlePickerClick}
-      className={classNames('w-[30px] h-[30px] absolute top-[21px] right-2', isPicked ? 'opacity-100' : 'opacity-50')}
+      className={classNames(
+        'w-[30px] h-[30px] absolute top-[21px] right-2 hover:animate-wobbleNoneOpacity',
+        isPicked ? 'opacity-100' : 'opacity-50',
+      )}
     >
       <Image src={monsterBall} alt="즐겨찾기" width={30} height={30} />
     </button>

--- a/src/app/_components/toast/ToastList.tsx
+++ b/src/app/_components/toast/ToastList.tsx
@@ -7,7 +7,7 @@ export default function ToastList() {
   const toastList = useToastStore(state => state.toastList);
 
   return (
-    <div className="fixed top-[200px] left-1/2 -translate-x-1/2 toast-z-index flex flex-col items-center gap-5 w-full">
+    <div className="fixed top-[200px] left-1/2 -translate-x-1/2 toast-z-index flex flex-col items-center gap-5 w-max pointer-events-none">
       {toastList.map(toast => (
         <Toast key={toast.id} id={toast.id} type={toast.type} message={toast.message} />
       ))}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -23,7 +23,7 @@
     z-index: 3;
   }
   .toast-z-index {
-    z-index: 2;
+    z-index: 3;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -69,6 +69,28 @@ const config: Config = {
             transform: 'translateX(-0.6px) rotate(-1.2deg)',
           },
         },
+        'wobble-none-opacity': {
+          '0%': {
+            transform: 'translateX(0%)',
+            'transform-origin': ' 50% 50%',
+          },
+          '100%': { transform: 'translateX(0%)', 'transform-origin': ' 50% 50%' },
+          '15%': {
+            transform: 'translateX(-3px) rotate(-6deg)',
+          },
+          '30%': {
+            transform: 'translateX(1.5px) rotate(6deg)',
+          },
+          '45%': {
+            transform: 'translateX(-1.5px) rotate(-7.6deg)',
+          },
+          '60%': {
+            transform: 'translateX(0.9px) rotate(4.4deg)',
+          },
+          '75%': {
+            transform: 'translateX(-0.6px) rotate(-1.2deg)',
+          },
+        },
         fadeIn: {
           '0%': { opacity: '0' },
           '100%': { opacity: '1' },
@@ -84,6 +106,7 @@ const config: Config = {
         backdropFadeIn: 'backdrop-fade-in 0.5s ease-out both',
         backdropFadeOut: 'backdrop-fade-out 0.5s ease-out both',
         wobbleHorBottom: 'wobble-hor-bottom 0.7s infinite ease-out both',
+        wobbleNoneOpacity: 'wobble-none-opacity 0.7s infinite ease-out both',
         fadeIn: 'fadeIn 0.6s ease-in-out',
         fadeOut: 'fadeOut 0.6s ease-in-out',
       },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -49,10 +49,8 @@ const config: Config = {
           '0%': {
             transform: 'translateX(0%)',
             'transform-origin': ' 50% 50%',
-            opacity: '0.8',
-            filter: 'brightness(0.7) saturate(100%)',
           },
-          '100%': { transform: 'translateX(0%)', 'transform-origin': ' 50% 50%', opacity: '1' },
+          '100%': { transform: 'translateX(0%)', 'transform-origin': ' 50% 50%' },
           '15%': {
             transform: 'translateX(-3px) rotate(-6deg)',
           },
@@ -105,7 +103,7 @@ const config: Config = {
         fadeOutBottom: 'fade-out-bottom 0.7s cubic-bezier(0.250, 0.460, 0.450, 0.940) both',
         backdropFadeIn: 'backdrop-fade-in 0.5s ease-out both',
         backdropFadeOut: 'backdrop-fade-out 0.5s ease-out both',
-        wobbleHorBottom: 'wobble-hor-bottom 0.7s infinite ease-out both',
+        wobbleHorBottom: 'wobble-hor-bottom 1.2s infinite ease-out both',
         wobbleNoneOpacity: 'wobble-none-opacity 0.7s infinite ease-out both',
         fadeIn: 'fadeIn 0.6s ease-in-out',
         fadeOut: 'fadeOut 0.6s ease-in-out',


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 포케피커 호버링 및 추가 효과 및 드래거블 메뉴 스타일 수정

## 📝 작업 내용 설명
- 포케피커에 호버링 효과를 주었습니다.
- 포케피커로 포켓몬을 포케박스에 추가할 때 별 스파클링 이펙트가 나옵니다.
- 드래거블 메뉴의 배경을 없애고, 평시, 등장, 호버링, 클릭에 애니메이션을 주었습니다.
- 호버링 시 워블 효과가 없어지고, 툴팁이 뜹니다.
- 토스트가 한줄 전체를 차지하는 것을 컴포넌트 자체 크기 만큼으로 줄이고, 클릭 이벤트를 막아 클릭에 방해되지 않도록 하였습니다.

## 📷 스크린샷

![화면 기록 2024-11-18 오후 11 59 09-3](https://github.com/user-attachments/assets/5102f8a0-1bf9-41c0-baed-9104d048e4cf)

![화면 기록 2024-11-18 오후 10 02 57-1](https://github.com/user-attachments/assets/ce76ca41-7550-419e-b9d0-9b1f411d703c)

## 💬 리뷰 요구사항
- 한영 변환 텍스트는 다음 PR에 한 번에 올리겠습니다!

## 🏷️ 연관된 이슈 번호
> [#44 몬스터볼 애니메이션 효과 적용](#44)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
