### PR TITLE
Refactor: pokebox 관련 로직을 전역 상태로 관리할 수 있도록 개선

### DIFF
--- a/src/app/_components/main/PokePicker.tsx
+++ b/src/app/_components/main/PokePicker.tsx
@@ -1,51 +1,31 @@
 import classNames from 'classnames';
 import Image from 'next/image';
 import monsterBall from '@/images/items/poke-ball.webp';
+import { usePokebox } from '@/stores/usePokebox';
 import { useToastAction } from '@/stores/actions/useToastAction';
-import { useEffect, useState } from 'react';
 
 interface PokePickerProps {
   id: number;
   name: string;
 }
 
-const getPokebox = () => {
-  const storage = localStorage.getItem('pokebox');
-  return storage ? (JSON.parse(storage) as number[]) : null;
-};
-
 export default function PokePicker({ id, name }: PokePickerProps) {
   const { addToast } = useToastAction();
-  const [isPicked, setIsPicked] = useState<boolean>(false);
+  const {
+    checkIsPicked,
+    action: { addPokemon, removePokemon },
+  } = usePokebox();
+  const isPicked = checkIsPicked(id);
 
   const handlePickerClick = () => {
-    const pokebox = getPokebox();
-    if (pokebox) {
-      if (isPicked) {
-        localStorage.setItem('pokebox', JSON.stringify(pokebox.filter(v => v !== id)));
-        addToast({ type: 'error', message: `바이바이, ${name}!` });
-        setIsPicked(false);
-      } else {
-        localStorage.setItem('pokebox', JSON.stringify([...pokebox, id]));
-        addToast({ type: 'success', message: `${name}이(가) 포켓박스에 추가되었다!` });
-        setIsPicked(true);
-      }
+    if (isPicked) {
+      addToast({ type: 'error', message: `바이바이, ${name}!` });
+      removePokemon(id);
+    } else {
+      addToast({ type: 'success', message: `${name}이(가) 포켓박스에 추가되었다!` });
+      addPokemon(id);
     }
   };
-
-  useEffect(() => {
-    const pokebox = getPokebox();
-    if (pokebox) {
-      const isPickedPokemon = pokebox.find(v => v === id);
-      if (isPickedPokemon) {
-        setIsPicked(true);
-      } else {
-        setIsPicked(false);
-      }
-    } else {
-      localStorage.setItem('pokebox', JSON.stringify([]));
-    }
-  }, [isPicked]);
 
   return (
     <button

--- a/src/stores/usePokebox.ts
+++ b/src/stores/usePokebox.ts
@@ -1,0 +1,41 @@
+import { PokeboxStore } from '@/types/pokebox';
+import { create } from 'zustand';
+
+const getPokebox = () => {
+  if (typeof window === 'undefined') {
+    // SSR 방어
+    return [];
+  }
+
+  const storage = localStorage.getItem('pokebox');
+
+  if (!storage) {
+    // 스토리지가 없다면 생성.
+    localStorage.setItem('pokebox', JSON.stringify([]));
+    return [];
+  }
+
+  return JSON.parse(storage) as number[];
+};
+
+const initialPokebox = getPokebox();
+
+export const usePokebox = create<PokeboxStore>((set, get) => {
+  const updatePokebox = (updatedPokebox: number[]) => {
+    localStorage.setItem('pokebox', JSON.stringify(updatedPokebox));
+    set({ pokebox: updatedPokebox });
+  };
+
+  return {
+    pokebox: initialPokebox,
+    checkIsPicked: (id: number) => get().pokebox.includes(id),
+    action: {
+      addPokemon: id => {
+        updatePokebox([...get().pokebox, id]);
+      },
+      removePokemon: id => {
+        updatePokebox(get().pokebox.filter(v => v !== id));
+      },
+    },
+  };
+});

--- a/src/types/pokebox.ts
+++ b/src/types/pokebox.ts
@@ -1,0 +1,10 @@
+export type Pokebox = number[];
+
+export interface PokeboxStore {
+  pokebox: Pokebox;
+  checkIsPicked: (id: number) => boolean;
+  action: {
+    addPokemon: (id: number) => void;
+    removePokemon: (id: number) => void;
+  };
+}


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 포켓몬 상세 모달에서 포켓몬을 추가, 삭제할 경우,
도감 페이지에서 바로 적용되지 않는 문제가 있어 전역 상태로 리팩토링함

## 📝 작업 내용 설명
- 전역 스토어로 usePokebox를 제작했습니다.
- 액션 함수 내부에서 로컬 스토리지 관련 로직을 처리하니, 따로 로컬 스토리지에 접근하지 않아도 됩니다.
- usePokebox는 pokebox, checkIsPicked, action: {addPokemon, removePokemon} 을 반환합니다.

```tsx
  // pokebox: number[]로 포켓몬 id 배열입니다.
  // checkIsPicked(id: number): id를 인자로 넘기면 해당 인자가 pokebox에 있는지 검사하여 boolean값을 반환합니다.
  // addPokemon(id: number): 해당 포켓몬 id를 pokebox에 추가합니다.
  // removePokemon(id: number): 해당 포켓몬 id를 pokebox에서 제거합니다.
  const {
    pokebox,
    checkIsPicked,
    action: { addPokemon, removePokemon },
  } = usePokebox();
  
  // 상태 변경에 의한 리렌더링과 무관한 곳에서
  // 불필요한 컴포넌트 리렌더링 없이 액션 함수만 사용하고 싶다면 아래와 같이 사용하시면 됩니다.
  const { addPokemon, removePokemon } = usePokebox(state => state.action)
```

## 💬 리뷰 요구사항(선택)
> 문제점이나 개선 방안이 있다면 알려주세요!

## 🏷️ 연관된 이슈 번호
> [#49 내 포켓몬 저장 데이터 전역 상태로 전환](#49)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
