### PR TITLE
Refactor 포켓몬 상세 모달 캐러셀 기능 수정

### DIFF
--- a/src/app/_components/pokemonModal/PokemonModal.tsx
+++ b/src/app/_components/pokemonModal/PokemonModal.tsx
@@ -47,7 +47,15 @@ export default function PokemonModal({ turnOffToggle, pokemonNumber, carousel }:
     <div className="relative w-screen max-w-[90%] sm:max-w-[500px] md:max-w-[700px] h-[75vh] max-h-[700px] bg-[#F0F0F0] rounded-2xl mx-auto p-2 md:p-4">
       <div className="flex flex-col justify-between h-full bg-[#79C9FA] rounded-2xl overflow-y-auto">
         <ModalTitle pokemonData={data} onTurnOffToggle={turnOffToggle} language={language} />
-        <ModalImage pokemonData={data} number={number} setNumber={setNumber} shiny={shiny} carousel={carousel} />
+        <ModalImage
+          pokemonData={data}
+          number={number}
+          setNumber={setNumber}
+          shiny={shiny}
+          setShiny={setShiny}
+          setTabActive={setTabActive}
+          carousel={carousel}
+        />
         <div>
           <ModalTabMenu
             tabActive={tabActive}

--- a/src/app/_components/pokemonModal/components/ModalImage.tsx
+++ b/src/app/_components/pokemonModal/components/ModalImage.tsx
@@ -5,11 +5,21 @@ interface ModalImageProps {
   pokemonData: any;
   number: number;
   setNumber: React.Dispatch<React.SetStateAction<number>>;
+  setShiny: React.Dispatch<React.SetStateAction<boolean>>;
   shiny: boolean;
   carousel: boolean | undefined;
+  setTabActive: React.Dispatch<React.SetStateAction<string>>;
 }
 
-export default function ModalImage({ pokemonData, number, setNumber, shiny, carousel = true }: ModalImageProps) {
+export default function ModalImage({
+  pokemonData,
+  number,
+  setNumber,
+  shiny,
+  setShiny,
+  carousel = true,
+  setTabActive,
+}: ModalImageProps) {
   const pokemonImage = shiny ? pokemonData?.shiny : pokemonData?.image;
   return (
     <>
@@ -24,6 +34,8 @@ export default function ModalImage({ pokemonData, number, setNumber, shiny, caro
             )}
             onClick={() => {
               setNumber(prev => prev - 1);
+              setShiny(false);
+              setTabActive('info');
             }}
             disabled={number === 1}
           >
@@ -38,6 +50,8 @@ export default function ModalImage({ pokemonData, number, setNumber, shiny, caro
             )}
             onClick={() => {
               setNumber(prev => prev + 1);
+              setShiny(false);
+              setTabActive('info');
             }}
             disabled={number === 1025}
           >


### PR DESCRIPTION
## ✏️ 작업 내용 요약
- 포켓몬 상세 모달 캐러셀 기능 수정

## 📝 작업 내용 설명
- 기존에는 포켓몬 상세 모달에서 특성을 변경하거나 이로치 활성화 시킨 상세로 캐러셀 이동하면 탭과 이로치 상태를 유지하는 현상 발생하여 캐러셀 기능에 탭과 이로치 초기화 추가

## 📷 스크린샷 (선택)
### 수정 전
https://github.com/user-attachments/assets/522672db-436d-4937-bc96-af7ceb292dce

### 수정 후
https://github.com/user-attachments/assets/68d78921-18d0-461c-b9d8-90aa80ad85c2

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 🏷️ 연관된 이슈 번호
- #52 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
