### PR TITLE
#51 feat: 언어 변환에 따른 텍스트 상수화

### DIFF
--- a/src/app/_components/draggableSearchMenu/MonsterBall.tsx
+++ b/src/app/_components/draggableSearchMenu/MonsterBall.tsx
@@ -1,12 +1,15 @@
 import Image from 'next/image';
 import pokeBall from '@/images/items/poke-ball.webp';
 import { Tooltip } from 'react-tooltip';
+import { useLanguageStore } from '@/stores/useLanguageStore';
+import { localeText } from '@/constants/localeText';
 
 interface MonsterBallProps {
   onClick: () => void;
 }
 
 export default function MonsterBall({ onClick }: MonsterBallProps) {
+  const { language } = useLanguageStore();
   return (
     <>
       <div
@@ -17,7 +20,7 @@ export default function MonsterBall({ onClick }: MonsterBallProps) {
         <Image className="active:pointer-events-none " src={pokeBall} alt="몬스터볼 이미지" height={60} width={60} />
       </div>
       <Tooltip anchorSelect="#monsterBall" place="top">
-        가랏, 몬스터볼!
+        {localeText[language].draggableTooltip}
       </Tooltip>
     </>
   );

--- a/src/app/_components/main/PokePicker.tsx
+++ b/src/app/_components/main/PokePicker.tsx
@@ -5,6 +5,8 @@ import { usePokebox } from '@/stores/usePokebox';
 import { useToastAction } from '@/stores/actions/useToastAction';
 import { MouseEvent } from 'react';
 import party from 'party-js';
+import { localeText } from '@/constants/localeText';
+import { useLanguageStore } from '@/stores/useLanguageStore';
 
 interface PokePickerProps {
   id: number;
@@ -12,6 +14,7 @@ interface PokePickerProps {
 }
 
 export default function PokePicker({ id, name }: PokePickerProps) {
+  const { language } = useLanguageStore();
   const { addToast } = useToastAction();
   const {
     checkIsPicked,
@@ -21,7 +24,7 @@ export default function PokePicker({ id, name }: PokePickerProps) {
 
   const handlePickerClick = (event: MouseEvent<HTMLButtonElement>) => {
     if (isPicked) {
-      addToast({ type: 'error', message: `바이바이, ${name}!` });
+      addToast({ type: 'error', message: `${localeText[language].dropPokemon} ${name}!` });
       removePokemon(id);
     } else {
       party.sparkles(event.target as HTMLButtonElement, {
@@ -29,7 +32,7 @@ export default function PokePicker({ id, name }: PokePickerProps) {
         speed: 80,
         size: party.variation.range(0.8, 1.2),
       });
-      addToast({ type: 'success', message: `${name}이(가) 포켓박스에 추가되었다!` });
+      addToast({ type: 'success', message: `${name}${localeText[language].pickPokemon}` });
       addPokemon(id);
     }
   };

--- a/src/constants/localeText.ts
+++ b/src/constants/localeText.ts
@@ -1,0 +1,12 @@
+export const localeText = {
+  en: {
+    pickPokemon: 'was sent to the PokéBox!',
+    dropPokemon: 'Goodbye,',
+    draggableTooltip: 'Go, pokéball!',
+  },
+  ko: {
+    pickPokemon: '이(가) 포켓박스에 추가되었다!',
+    dropPokemon: '바이바이,',
+    draggableTooltip: '가랏, 몬스터볼!',
+  },
+};


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 언어 변환에 따른 텍스트 상수화

## 📝 작업 내용 설명
- constants/localeText.ts 파일에 언어에 따른 텍스트 상수 파일을 생성하였습니다.
- 해당 파일에 텍스트 이어서 작성해주시면 됩니다!

## 📷 스크린샷


https://github.com/user-attachments/assets/2efe2835-4f9d-4b25-a498-10fb0dc7da04



## 💬 리뷰 요구사항
- 이슈 번호는 #51 써주시면 되고, 혹시나 브랜치명 겹칠까봐 localeText에 이름으로 덧붙였습니다!

## 🏷️ 연관된 이슈 번호
> [#51 한/영 변환 텍스트 상수화](#51)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
