### PR TITLE
Fix: 포켓몬 모달 이로치 노출 이미지 딜레이 수정

### DIFF
--- a/src/app/_components/landing/PokemonQuiz.tsx
+++ b/src/app/_components/landing/PokemonQuiz.tsx
@@ -96,6 +96,7 @@ export default function PokemonQuiz() {
         height={250}
         draggable={false}
         alt={localeText[language].quizPokemonImage}
+        priority
       />
       <div className="flex flex-col justify-center items-center w-full gap-3 sm:gap-5">
         {isSubmit && <p className="text-xl sm:text-2xl leading-9">{data?.pokemonName}</p>}

--- a/src/app/_components/pokemonModal/components/FavoritePokemon.tsx
+++ b/src/app/_components/pokemonModal/components/FavoritePokemon.tsx
@@ -15,7 +15,7 @@ export default function FavoritePokemon({
   return (
     <div className="flex flex-col items-center">
       <div className="w-[110px] h-[110px] sm:w-[120px] sm:h-[120px] relative">
-        <Image src={image} className="object-contain py-5" fill sizes="100vw, 100vw" alt="포켓몬 이미지" />
+        <Image src={image} className="object-contain py-5" fill sizes="100vw, 100vw" alt="포켓몬 이미지" priority />
       </div>
       <div className="flex items-center mt-2">
         <h3 className="outline-text text-sm sm:text-base md:text-lg">{name}</h3>

--- a/src/app/_components/pokemonModal/components/ModalImage.tsx
+++ b/src/app/_components/pokemonModal/components/ModalImage.tsx
@@ -66,6 +66,7 @@ export default function ModalImage({
           height={150}
           className="w-[100px] md:w-[150px]"
           alt={pokemonData?.name ? `${pokemonData.name} 이미지` : '포켓몬 이미지'}
+          priority
         />
       </div>
     </>


### PR DESCRIPTION
## ✏️ 작업 내용 요약
- 포켓몬 모달 이로치 노출 이미지 딜레이 수정

## 📝 작업 내용 설명
- 포켓몬 모달 이로치 토글을 클릭했을때 이미지 변환 딜레이가 생겨서 Image 컴포넌트에 priority 속성을 사용하여 우선순위 적용

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/77e9df80-dd67-419d-ba6c-5e0b04835654



## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 🏷️ 연관된 이슈 번호
 - #61 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
