### PR TITLE
refator: 검색 인풋 placeholder 상수화 및 모달 내부 문구 단축

### DIFF
--- a/src/app/_components/main/SearchSection.tsx
+++ b/src/app/_components/main/SearchSection.tsx
@@ -7,6 +7,7 @@ import { TYPE_BY_COLOR } from '@/constants/mappingTypeColor';
 import { ChangeEvent, FormEvent, useState } from 'react';
 import { useLanguageStore } from '@/stores/useLanguageStore';
 import { FilteredPokemonArr } from '@/types/filteredPokemon';
+import { localeText } from '@/constants/localeText';
 
 const staggerContainer = {
   hidden: { opacity: 0 },
@@ -79,7 +80,9 @@ export default function SearchSection({
             onChange={handleInputChange}
             value={searchValue}
             name="pokemonName"
-            placeholder={language === 'ko' ? '찾으실 포켓몬 이름을 입력하세요.' : 'Enter the Pokémon name.'}
+            placeholder={
+              isModal ? localeText[language].modalSearchInputPlaceholder : localeText[language].searchInputPlaceholder
+            }
             className=" w-full bg-transparent px-3 py-1 outline-none"
           />
           <button type="submit" className="w-20 h-full rounded-md bg-gray-200 shadow-xl">

--- a/src/constants/localeText.ts
+++ b/src/constants/localeText.ts
@@ -24,6 +24,8 @@ export const localeText = {
     modalNotAbility: 'No abilities.',
     modalFavoriteTitle: 'Favorite',
     modalNotFavoritePokemon: 'No caught Pokémon...',
+    searchInputPlaceholder: 'Enter the Pokémon name.',
+    modalSearchInputPlaceholder: 'Pokémon name.',
   },
   ko: {
     pickPokemon: '이(가) 포켓박스에 추가되었다!',
@@ -50,5 +52,7 @@ export const localeText = {
     modalNotAbility: '특성이 없습니다.',
     modalFavoriteTitle: '내 포켓몬',
     modalNotFavoritePokemon: '잡은 포켓몬이 없어요...',
+    searchInputPlaceholder: '찾으실 포켓몬 이름을 입력하세요.',
+    modalSearchInputPlaceholder: '포켓몬 이름',
   },
 };


### PR DESCRIPTION
## ✏️ 작업 내용 요약
검색 인풋 placeholder 상수화 및 모달 내부 문구 단축

## 📝 작업 내용 설명
모달 내부에서 문구를 포켓몬 이름, pokemon name 으로 단축했습니다.

## 📷 스크린샷 (선택)
![스크린샷 2024-11-27 151923](https://github.com/user-attachments/assets/8e1bced8-a9e0-4091-add7-388068684726)
![스크린샷 2024-11-27 151933](https://github.com/user-attachments/assets/bacb4a85-a6a5-4843-bff5-46c720747494)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 🏷️ 연관된 이슈 번호
#64

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
