### PR TITLE
Refactor: 로딩컴포넌트 수정

### DIFF
--- a/src/app/_components/main/PokedexMain.tsx
+++ b/src/app/_components/main/PokedexMain.tsx
@@ -30,24 +30,24 @@ export default function PokedexMain() {
     typePokemonData,
     fetchTypePokemonNextPage,
     hasMoreType,
-    isFetchingNextPage: isFetchingType,
+    isFetching: isFetchingType,
   } = useInfinityTypePokemons();
 
   const {
-    searchedPokemon,
+    data: searchedPokemon,
     handleSubmit,
     handleInputChange,
     searchValue,
     handleResetSearchedPokemon,
     filteredPokemon,
     handleClickFilteredPokemon,
+    isFetching: isFetchingSearch,
   } = useSearchPokemon();
 
   const { targetRef, saveScrollPosition } = useInfiniteScroll(() => {
     saveScrollPosition();
     fetchAllPokemonNextPage();
   }, hasMore);
-
   const { targetRef: typeTargetRef, saveScrollPosition: typePosition } = useInfiniteScroll(
     () => {
       typePosition();
@@ -66,6 +66,7 @@ export default function PokedexMain() {
 
       <LanguageToggleButton />
       <MyFavoriteButton />
+
       <SearchSection
         searchValue={searchValue}
         handleInputChange={handleInputChange}
@@ -77,14 +78,16 @@ export default function PokedexMain() {
         filteredPokemon={filteredPokemon.length > 0 ? filteredPokemon : NOT_FOUND_POKEMON}
         handleClickFilteredPokemon={handleClickFilteredPokemon}
       />
-      {activedTypeNum === null && searchedPokemon === null && (
+      {((searchedPokemon && searchedPokemon.pages[0].length > 0) || isFetchingSearch) && (
+        <PokemonList pokemonData={searchedPokemon} carousel={false} />
+      )}
+      {activedTypeNum === null && !(searchedPokemon && searchedPokemon.pages[0].length > 0) && !isFetchingSearch && (
         <PokemonList pokemonData={allPokemonData} targetRef={targetRef} />
       )}
-      {!!activedTypeNum && searchedPokemon === null && (
+      {!!activedTypeNum && !(searchedPokemon && searchedPokemon.pages[0].length > 0) && !isFetchingSearch && (
         <PokemonList pokemonData={typePokemonData} targetRef={typeTargetRef} carousel={false} />
       )}
-      {searchedPokemon && <PokemonList pokemonData={searchedPokemon} carousel={false} />}
-      {searchedPokemon === false && <div>없음</div>}
+
       <DraggableMenu>
         <SearchSection
           searchValue={searchValue}

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -24,7 +24,7 @@ export default async function MainPage() {
     <div className="flex flex-col justify-between relative items-center gap-20 m-auto mt-10 w-full min-h-[500px] sm:min-h-[700px] pb-6 sm:pb-10 max-w-[1200px] rounded-3xl bg-[#F2F4F6] border-4 border-[#ffffff] px-[10px]">
       <MainTitle />
       <QuizButton />
-      <div className="flex flex-col w-full">
+      <div className="flex flex-col w-full grow">
         <HydrationBoundary state={dehydratedState}>
           <PokedexMain />
         </HydrationBoundary>

--- a/src/hooks/useInfinityPokemons.ts
+++ b/src/hooks/useInfinityPokemons.ts
@@ -24,6 +24,9 @@ const useInfinityPokemon = () => {
       setHasMore(false);
       return undefined;
     },
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 
   return { allPokemonData, fetchNextPage, hasMore, isFetchingNextPage };

--- a/src/hooks/useInfinityTypePokemons.ts
+++ b/src/hooks/useInfinityTypePokemons.ts
@@ -20,7 +20,7 @@ function useInfinityTypePokemons() {
   const {
     data: typePokemonData,
     fetchNextPage: fetchTypePokemonNextPage,
-    isFetchingNextPage,
+    isFetching,
     hasNextPage,
   } = useInfiniteQuery({
     queryKey: [POKEMON_QUERY_KEY, activedTypeNum, language],
@@ -39,6 +39,7 @@ function useInfinityTypePokemons() {
       return undefined;
     },
     enabled: activedTypeNum !== null,
+    staleTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
@@ -49,7 +50,6 @@ function useInfinityTypePokemons() {
       setHasMoreType(true);
     }
   }, [hasNextPage]);
-
   return {
     activedTypeNum,
     handleResetButton,
@@ -57,7 +57,7 @@ function useInfinityTypePokemons() {
     typePokemonData,
     fetchTypePokemonNextPage,
     hasMoreType,
-    isFetchingNextPage,
+    isFetching,
   };
 }
 export default useInfinityTypePokemons;

--- a/src/hooks/useSearchPokemon.ts
+++ b/src/hooks/useSearchPokemon.ts
@@ -13,10 +13,9 @@ function useSearchPokemon() {
   //검색된 데이터 관리
   const [searchValue, setSearchValue] = useState('');
   const [queryValue, setQueryValue] = useState('');
-  const [searchedPokemon, setSearchedPokemon] = useState<InfiniteData<PokemonInfo[]> | false | null>(null);
   const [filteredPokemon, setFilteredPokemon] = useState<FilteredPokemonArr[]>([]);
   const handleResetSearchedPokemon = () => {
-    setSearchedPokemon(null);
+    setQueryValue('');
   };
   const { language } = useLanguageStore();
 
@@ -73,19 +72,19 @@ function useSearchPokemon() {
     setFilteredPokemon([]);
   };
 
-  useQuery({
+  const { data, isFetching } = useQuery({
     queryKey: [POKEMON_QUERY_KEY, queryValue],
     queryFn: async () => {
       const response = await getPokemonInfo({ number: queryValue, language });
       if (!response) {
-        return setSearchedPokemon(false);
+        return;
       } else {
         const nextData = {
           pages: [[response]],
           pageParams: [],
         };
         //무한스크롤 쿼리들과 형식을 맞추기 위해서
-        setSearchedPokemon(nextData);
+
         return nextData;
       }
     },
@@ -96,12 +95,13 @@ function useSearchPokemon() {
   return {
     searchValue,
     queryValue,
-    searchedPokemon,
+    data,
     handleSubmit,
     handleInputChange,
     handleResetSearchedPokemon,
     handleClickFilteredPokemon,
     filteredPokemon,
+    isFetching,
   };
 }
 export default useSearchPokemon;


### PR DESCRIPTION
## ✏️ 작업 내용 요약
타입 변경시 로딩 컴포넌트 삽입
포켓몬 검색시 잠깐 전체포켓몬을 뜨는 문제 해결

## 📝 작업 내용 설명
- 타입 변경시 로딩 컴포넌트 삽입
- 포켓몬 검색시 로딩 컴포넌트 삽입을 해봤으나 로딩시간이 짧아 오히려 UX를 해쳤습니다 그래서 전체 포켓몬이 잠깐 뜨는 문제를 해결하고 아무것도 랜더링 안되도록 패치하여 자연스럽게 바꿨습니다.
- staleTime을 모두 infinity로 조정하여 한번 불러온 데이터를 다시 패칭하지 않도록 하였습니다.

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/7789eed9-2a03-4e8c-8086-7d171f16d502


## 💬 리뷰 요구사항(선택)
PokeList 컴포넌트를 랜더링하는 조건식이 복잡한데 차후에 TS-pattern 이라는 라이브러리를 활용하거나 다른 가독성을 높일 수 있는 방법을 찾아보겠습니다.

## 🏷️ 연관된 이슈 번호
#66 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [ ] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
