### PR TITLE
Fix: 모달 자동 닫기 및 오류 수정

### DIFF
--- a/src/app/_components/main/PokedexMain.tsx
+++ b/src/app/_components/main/PokedexMain.tsx
@@ -30,24 +30,24 @@ export default function PokedexMain() {
     typePokemonData,
     fetchTypePokemonNextPage,
     hasMoreType,
-    isFetchingNextPage: isFetchingType,
+    isFetching: isFetchingType,
   } = useInfinityTypePokemons();
 
   const {
-    searchedPokemon,
+    data: searchedPokemon,
     handleSubmit,
     handleInputChange,
     searchValue,
     handleResetSearchedPokemon,
     filteredPokemon,
     handleClickFilteredPokemon,
+    isFetching: isFetchingSearch,
   } = useSearchPokemon();
 
   const { targetRef, saveScrollPosition } = useInfiniteScroll(() => {
     saveScrollPosition();
     fetchAllPokemonNextPage();
   }, hasMore);
-
   const { targetRef: typeTargetRef, saveScrollPosition: typePosition } = useInfiniteScroll(
     () => {
       typePosition();
@@ -66,6 +66,7 @@ export default function PokedexMain() {
 
       <LanguageToggleButton />
       <MyFavoriteButton />
+
       <SearchSection
         searchValue={searchValue}
         handleInputChange={handleInputChange}
@@ -77,14 +78,16 @@ export default function PokedexMain() {
         filteredPokemon={filteredPokemon.length > 0 ? filteredPokemon : NOT_FOUND_POKEMON}
         handleClickFilteredPokemon={handleClickFilteredPokemon}
       />
-      {activedTypeNum === null && searchedPokemon === null && (
+      {((searchedPokemon && searchedPokemon.pages[0].length > 0) || isFetchingSearch) && (
+        <PokemonList pokemonData={searchedPokemon} carousel={false} />
+      )}
+      {activedTypeNum === null && !(searchedPokemon && searchedPokemon.pages[0].length > 0) && !isFetchingSearch && (
         <PokemonList pokemonData={allPokemonData} targetRef={targetRef} />
       )}
-      {!!activedTypeNum && searchedPokemon === null && (
+      {!!activedTypeNum && !(searchedPokemon && searchedPokemon.pages[0].length > 0) && !isFetchingSearch && (
         <PokemonList pokemonData={typePokemonData} targetRef={typeTargetRef} carousel={false} />
       )}
-      {searchedPokemon && <PokemonList pokemonData={searchedPokemon} carousel={false} />}
-      {searchedPokemon === false && <div>없음</div>}
+
       <DraggableMenu>
         <SearchSection
           searchValue={searchValue}

--- a/src/app/_components/main/PokedexMain.tsx
+++ b/src/app/_components/main/PokedexMain.tsx
@@ -42,8 +42,9 @@ export default function PokedexMain() {
     filteredPokemon,
     handleClickFilteredPokemon,
     isFetching: isFetchingSearch,
+    isModalOpen,
+    changeModalOpenValue,
   } = useSearchPokemon();
-
   const { targetRef, saveScrollPosition } = useInfiniteScroll(() => {
     saveScrollPosition();
     fetchAllPokemonNextPage();
@@ -56,6 +57,7 @@ export default function PokedexMain() {
     hasMoreType,
     activedTypeNum,
   );
+
   return (
     <>
       {(isFetchingPokemon || isFetchingType) && (
@@ -77,6 +79,8 @@ export default function PokedexMain() {
         handleResetSearchedPokemon={handleResetSearchedPokemon}
         filteredPokemon={filteredPokemon.length > 0 ? filteredPokemon : NOT_FOUND_POKEMON}
         handleClickFilteredPokemon={handleClickFilteredPokemon}
+        changeModalOpenValue={changeModalOpenValue}
+        isModalOpen={isModalOpen}
       />
       {((searchedPokemon && searchedPokemon.pages[0].length > 0) || isFetchingSearch) && (
         <PokemonList pokemonData={searchedPokemon} carousel={false} />
@@ -97,6 +101,8 @@ export default function PokedexMain() {
           handleResetButton={handleResetButton}
           handleSubmit={handleSubmit}
           handleResetSearchedPokemon={handleResetSearchedPokemon}
+          changeModalOpenValue={changeModalOpenValue}
+          isModalOpen={isModalOpen}
           isModal
         />
       </DraggableMenu>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -24,7 +24,7 @@ export default async function MainPage() {
     <div className="flex flex-col justify-between relative items-center gap-20 m-auto mt-10 w-full min-h-[500px] sm:min-h-[700px] pb-6 sm:pb-10 max-w-[1200px] rounded-3xl bg-[#F2F4F6] border-4 border-[#ffffff] px-[10px]">
       <MainTitle />
       <QuizButton />
-      <div className="flex flex-col w-full">
+      <div className="flex flex-col w-full grow">
         <HydrationBoundary state={dehydratedState}>
           <PokedexMain />
         </HydrationBoundary>

--- a/src/hooks/useInfinityPokemons.ts
+++ b/src/hooks/useInfinityPokemons.ts
@@ -24,6 +24,9 @@ const useInfinityPokemon = () => {
       setHasMore(false);
       return undefined;
     },
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 
   return { allPokemonData, fetchNextPage, hasMore, isFetchingNextPage };

--- a/src/hooks/useInfinityTypePokemons.ts
+++ b/src/hooks/useInfinityTypePokemons.ts
@@ -20,7 +20,7 @@ function useInfinityTypePokemons() {
   const {
     data: typePokemonData,
     fetchNextPage: fetchTypePokemonNextPage,
-    isFetchingNextPage,
+    isFetching,
     hasNextPage,
   } = useInfiniteQuery({
     queryKey: [POKEMON_QUERY_KEY, activedTypeNum, language],
@@ -39,6 +39,7 @@ function useInfinityTypePokemons() {
       return undefined;
     },
     enabled: activedTypeNum !== null,
+    staleTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
@@ -49,7 +50,6 @@ function useInfinityTypePokemons() {
       setHasMoreType(true);
     }
   }, [hasNextPage]);
-
   return {
     activedTypeNum,
     handleResetButton,
@@ -57,7 +57,7 @@ function useInfinityTypePokemons() {
     typePokemonData,
     fetchTypePokemonNextPage,
     hasMoreType,
-    isFetchingNextPage,
+    isFetching,
   };
 }
 export default useInfinityTypePokemons;

--- a/src/hooks/useSearchPokemon.ts
+++ b/src/hooks/useSearchPokemon.ts
@@ -13,10 +13,9 @@ function useSearchPokemon() {
   //검색된 데이터 관리
   const [searchValue, setSearchValue] = useState('');
   const [queryValue, setQueryValue] = useState('');
-  const [searchedPokemon, setSearchedPokemon] = useState<InfiniteData<PokemonInfo[]> | false | null>(null);
   const [filteredPokemon, setFilteredPokemon] = useState<FilteredPokemonArr[]>([]);
   const handleResetSearchedPokemon = () => {
-    setSearchedPokemon(null);
+    setQueryValue('');
   };
   const { language } = useLanguageStore();
 
@@ -73,19 +72,19 @@ function useSearchPokemon() {
     setFilteredPokemon([]);
   };
 
-  useQuery({
+  const { data, isFetching } = useQuery({
     queryKey: [POKEMON_QUERY_KEY, queryValue],
     queryFn: async () => {
       const response = await getPokemonInfo({ number: queryValue, language });
       if (!response) {
-        return setSearchedPokemon(false);
+        return;
       } else {
         const nextData = {
           pages: [[response]],
           pageParams: [],
         };
         //무한스크롤 쿼리들과 형식을 맞추기 위해서
-        setSearchedPokemon(nextData);
+
         return nextData;
       }
     },
@@ -96,12 +95,13 @@ function useSearchPokemon() {
   return {
     searchValue,
     queryValue,
-    searchedPokemon,
+    data,
     handleSubmit,
     handleInputChange,
     handleResetSearchedPokemon,
     handleClickFilteredPokemon,
     filteredPokemon,
+    isFetching,
   };
 }
 export default useSearchPokemon;


### PR DESCRIPTION
## ✏️ 작업 내용 요약
- 모달 내부에서 검색, 타입 버튼 클릭시 모달이 닫힙니다.
- 모달을 열었을 때 외부 검색창이 초기화 됩니다.
- 존재하지 않는 포켓몬 검색시 토스트팝업이 뜹니다.

## 📝 작업 내용 설명

모달 내 외부 input을 분리할 수 있는 가장 오류없고 간단한 방법을 생각해봤습니다.

모달 외부 검색창(searchSection컴포넌트)은 항상 가장 먼저 마운트되고
모달 내부 검색창은 isModal = true라는 props 를 전달 받는 점을 이용,
searchSection 컴포넌트에 useEffect를 추가해 컴포넌트가 마운트될 때 isModal을 전달 받으면 부모의 isModalOpen 상태를 변동시켜 모달이 열려있는지 열려있지 않은지 상태를 파악할 수 있습니다.
isModal과 isModalOpen의 상태를 활용해 조건부로 랜더링하도록 구현하여 기존 코드의 변화 없이 오류를 처리했습니다.

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/38c80570-4054-4a76-ab0f-336f3bf88d72



## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 🏷️ 연관된 이슈 번호
#68 


## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [ ] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
