### PR TITLE
Fix: 메인 페이지 진입시 RSC가 빌드되어 있으나 로딩을 하던 문제 수정

### DIFF
--- a/src/app/_components/Providers.tsx
+++ b/src/app/_components/Providers.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
 import Portal from './modal/Portal';
 import ToastList from './toast/ToastList';
@@ -11,6 +12,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <Portal elementId="toast">
         <ToastList />
+        <ReactQueryDevtools initialIsOpen={true} />
       </Portal>
       {children}
     </QueryClientProvider>

--- a/src/app/_components/main/PokedexMain.tsx
+++ b/src/app/_components/main/PokedexMain.tsx
@@ -12,9 +12,6 @@ import LanguageToggleButton from '../button/LanguageToggleButton';
 import DraggableMenu from '../draggableSearchMenu/DraggableMenu';
 import { NOT_FOUND_POKEMON } from '@/constants/searchNotFound';
 
-/**PokemonList 컴포넌트를 UI화 하기위해 컨테이너 컴포넌트를 하나 만들어 관심사를 분리했습니다.
- * 민찬님이 작성해주신 로딩 컴포넌트를 해당 컴포넌트로 이동시켰습니다
- */
 export default function PokedexMain() {
   const {
     allPokemonData,

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -11,14 +11,16 @@ export default async function MainPage() {
 
   // 서버에서 데이터를 미리 가져옴
   await queryClient.prefetchInfiniteQuery({
-    queryKey: [POKEMON_QUERY_KEY],
-    queryFn: () => getPokemonAllList({ offset: undefined, limit: undefined, language: 'ko' }),
+    queryKey: [POKEMON_QUERY_KEY, 'ko'],
+    queryFn: () => {
+      return getPokemonAllList({ language: 'ko' });
+    },
+    staleTime: Infinity,
     initialPageParam: 0,
   });
 
   // 로딩시 보여줄 랜덤 포켓몬 이미지 prefetch
   await queryClient.prefetchQuery({ queryKey: ['loading'], queryFn: getLoadingPokemonImage });
-
   const dehydratedState = dehydrate(queryClient);
   return (
     <div className="flex flex-col justify-between relative items-center gap-20 m-auto mt-10 w-full min-h-[500px] sm:min-h-[700px] pb-6 sm:pb-10 max-w-[1200px] rounded-3xl bg-[#F2F4F6] border-4 border-[#ffffff] px-[10px]">


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 메인 페이지 초기화면에 캐시된 데이터를 보여주지 않던 문제 수정

## 📝 작업 내용 설명
> 기존 빌드 타임에 생성된 RSC에 기존 쿼리 클라이언트 상태가 직렬화되어 있었으나 실제 메인 페이지로 접속 시 로딩창과 함께 새로 데이터를 패칭하는 문제가 있었습니다.
-> 클라이언트의 쿼리 클라이언트 상태와 RSC의 쿼리 클라이언트 상태의 Query Key가 달라서 새로 패칭하는 문제임을 인지하고 수정했습니다.
-> 수정 후 메인페이지 진입이 로딩 없이 약 0.2초 내로 전환되었습니다.


## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
